### PR TITLE
Support using managed identity resource ID in AcrPullBinding

### DIFF
--- a/api/v1beta1/acrpullbinding_types.go
+++ b/api/v1beta1/acrpullbinding_types.go
@@ -38,12 +38,12 @@ type AcrPullBindingSpec struct {
 	// The full server name for the ACR. For example, test.azurecr.io
 	AcrServer string `json:"acrServer"`
 
-	// +kubebuilder:validation:MinLength=0
-
 	// The Managed Identity client ID that is used to authenticate with ACR (specify one of ClientID or ResourceID)
+	// +optional
 	ManagedIdentityClientID string `json:"managedIdentityClientID"`
 
 	// The Managed Identity resource ID that is used to authenticate with ACR (if ClientID is specified, this is ignored)
+	// +optional
 	ManagedIdentityResourceID string `json:"managedIdentityResourceID"`
 }
 

--- a/api/v1beta1/acrpullbinding_types.go
+++ b/api/v1beta1/acrpullbinding_types.go
@@ -40,7 +40,7 @@ type AcrPullBindingSpec struct {
 
 	// +kubebuilder:validation:MinLength=0
 
-	// The Managed Identity client ID that is used to authenticate with ACR (specify one off ClientID or ResourceID)
+	// The Managed Identity client ID that is used to authenticate with ACR (specify one of ClientID or ResourceID)
 	ManagedIdentityClientID string `json:"managedIdentityClientID"`
 
 	// The Managed Identity resource ID that is used to authenticate with ACR (if ClientID is specified, this is ignored)

--- a/api/v1beta1/acrpullbinding_types.go
+++ b/api/v1beta1/acrpullbinding_types.go
@@ -40,8 +40,11 @@ type AcrPullBindingSpec struct {
 
 	// +kubebuilder:validation:MinLength=0
 
-	// The Managed Identity client ID that is used to authenticate with ACR
+	// The Managed Identity client ID that is used to authenticate with ACR (specify one off ClientID or ResourceID)
 	ManagedIdentityClientID string `json:"managedIdentityClientID"`
+
+	// The Managed Identity resource ID that is used to authenticate with ACR (if ClientID is specified, this is ignored)
+	ManagedIdentityResourceID string `json:"managedIdentityResourceID"`
 }
 
 // AcrPullBindingStatus defines the observed state of AcrPullBinding

--- a/config/crd/bases/msi-acrpull.microsoft.com_acrpullbindings.yaml
+++ b/config/crd/bases/msi-acrpull.microsoft.com_acrpullbindings.yaml
@@ -43,7 +43,6 @@ spec:
             managedIdentityClientID:
               description: The Managed Identity client ID that is used to authenticate
                 with ACR (specify one of ClientID or ResourceID)
-              minLength: 0
               type: string
             managedIdentityResourceID:
               description: The Managed Identity resource ID that is used to authenticate
@@ -51,8 +50,6 @@ spec:
               type: string
           required:
           - acrServer
-          - managedIdentityClientID
-          - managedIdentityResourceID
           type: object
         status:
           description: AcrPullBindingStatus defines the observed state of AcrPullBinding

--- a/config/crd/bases/msi-acrpull.microsoft.com_acrpullbindings.yaml
+++ b/config/crd/bases/msi-acrpull.microsoft.com_acrpullbindings.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: acrpullbindings.msi-acrpull.microsoft.com
 spec:
@@ -42,12 +42,17 @@ spec:
               type: string
             managedIdentityClientID:
               description: The Managed Identity client ID that is used to authenticate
-                with ACR
+                with ACR (specify one off ClientID or ResourceID)
               minLength: 0
+              type: string
+            managedIdentityResourceID:
+              description: The Managed Identity resource ID that is used to authenticate
+                with ACR (if ClientID is specified, this is ignored)
               type: string
           required:
           - acrServer
           - managedIdentityClientID
+          - managedIdentityResourceID
           type: object
         status:
           description: AcrPullBindingStatus defines the observed state of AcrPullBinding

--- a/config/crd/bases/msi-acrpull.microsoft.com_acrpullbindings.yaml
+++ b/config/crd/bases/msi-acrpull.microsoft.com_acrpullbindings.yaml
@@ -42,7 +42,7 @@ spec:
               type: string
             managedIdentityClientID:
               description: The Managed Identity client ID that is used to authenticate
-                with ACR (specify one off ClientID or ResourceID)
+                with ACR (specify one of ClientID or ResourceID)
               minLength: 0
               type: string
             managedIdentityResourceID:

--- a/controllers/acrpullbinding_controller.go
+++ b/controllers/acrpullbinding_controller.go
@@ -48,9 +48,18 @@ func (r *AcrPullBindingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	}
 
 	msiClientID := acrBinding.Spec.ManagedIdentityClientID
+	msiResourceID := acrBinding.Spec.ManagedIdentityResourceID
 	acrServer := acrBinding.Spec.AcrServer
 
-	acrAccessToken, err := auth.AcquireACRAccessToken(msiClientID, acrServer)
+	var acrAccessToken auth.AccessToken
+	var err error
+
+	if msiClientID != "" {
+		acrAccessToken, err = auth.AcquireACRAccessTokenWithClientID(msiClientID, acrServer)
+	} else {
+		acrAccessToken, err = auth.AcquireACRAccessTokenWithResourceID(msiResourceID, acrServer)
+	}
+
 	if err != nil {
 		log.Error(err, "Failed to get ACR access token")
 		if err := r.setErrStatus(ctx, err, &acrBinding); err != nil {
@@ -134,7 +143,7 @@ func (r *AcrPullBindingReconciler) setSuccessStatus(ctx context.Context, acrBind
 	}
 
 	acrBinding.Status = msiacrpullv1beta1.AcrPullBindingStatus{
-		TokenExpirationTime: &metav1.Time{Time: tokenExp},
+		TokenExpirationTime:  &metav1.Time{Time: tokenExp},
 		LastTokenRefreshTime: &metav1.Time{Time: time.Now().UTC()},
 	}
 

--- a/controllers/acrpullbinding_controller.go
+++ b/controllers/acrpullbinding_controller.go
@@ -59,7 +59,6 @@ func (r *AcrPullBindingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	} else {
 		acrAccessToken, err = auth.AcquireACRAccessTokenWithResourceID(msiResourceID, acrServer)
 	}
-
 	if err != nil {
 		log.Error(err, "Failed to get ACR access token")
 		if err := r.setErrStatus(ctx, err, &acrBinding); err != nil {


### PR DESCRIPTION
Add support to use managed identity resource ID instead of client iD in AcrPullBiding.

This PR fixes #9 