### PR TITLE
fix: the workflow event condition on PR merge

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,5 +26,5 @@ jobs:
         password: ${{ secrets.ACR_PASSWORD }}
 
     - name: Push to CI ACR
-      if: github.event == 'push'
+      if: github.event.pull_request.merged == true
       run: make docker-push


### PR DESCRIPTION
Fix the workflow event condition on PR merge. The 'push' event seems only work for direct push to main branch.