### PR TITLE
Fix GH action push to ACR condition

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,5 +26,5 @@ jobs:
         password: ${{ secrets.ACR_PASSWORD }}
 
     - name: Push to CI ACR
-      if: github.event.pull_request.merged == true
+      if: github.event_name == 'push'
       run: make docker-push

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,6 +19,7 @@ jobs:
       run: make docker-build
 
     - name: Azure Container Registry Login
+      if: github.event_name == 'push'
       uses: Azure/docker-login@v1
       with:
         login-server: acrpullci.azurecr.io


### PR DESCRIPTION
Fix the push to ACR condition in workflow. Seems should have condition on the trigger event. it will be 'push' to master when a PR is merged.