### PR TITLE
Add Makefile target to build deploy artifacts

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,6 +31,14 @@ jobs:
     - name: Test
       run: make test
     
+    - name: Update release latest
+      run: make release-latest
+    
+    - name: Commit latest release
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Apply latest release artifacts
+    
     - name: Upload Code Coverage
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,14 +31,6 @@ jobs:
     - name: Test
       run: make test
     
-    - name: Update release latest
-      run: make release-latest
-    
-    - name: Commit latest release
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: Apply latest release artifacts
-    
     - name: Upload Code Coverage
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
 
     - name: Get dependencies
       run: go mod download
@@ -32,7 +34,9 @@ jobs:
       run: make test
     
     - name: Update release latest
-      run: make release-latest
+      run: |
+        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+        make release-latest
     
     - name: Commit latest release
       uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,8 +21,6 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-      with:
-        ref: ${{ github.head_ref }}
 
     - name: Get dependencies
       run: go mod download
@@ -34,9 +32,7 @@ jobs:
       run: make test
     
     - name: Update release latest
-      run: |
-        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
-        make release-latest
+      run: make release-latest
     
     - name: Commit latest release
       uses: stefanzweifel/git-auto-commit-action@v4

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= msi-acrpull:latest
+IMG ?= mcr.microsoft.com/aks/msi-acrpull
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
@@ -41,6 +41,12 @@ deploy: manifests
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+
+# Generate release artifects for latest tag
+release-latest: manifests
+	kustomize build config/crd > deploy/latest/crd.yaml
+	cd config/manager && kustomize edit set image controller=${IMG}
+	kustomize build config/default > deploy/latest/deploy.yaml
 
 # Run go fmt against code
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= mcr.microsoft.com/aks/msi-acrpull
+IMG ?= mcr.microsoft.com/aks/msi-acrpull:v0.1.0-alpha
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ kubectl apply -f https://raw.githubusercontent.com/Azure/msi-acrpull/main/deploy
 kubectl apply -f https://raw.githubusercontent.com/Azure/msi-acrpull/main/deploy/latest/deploy.yaml
 ```
 
+# How to use
+Once msi-acrpull installs to your cluster. All you need is to deploy a custom resource `ACRPullBinding` to the application namesapce to bind an user assigned identity to an ACR. Following sample specifies all pods in the namespace to use user managed identity `my-acr-puller` to pull image from `veryimportantcr.azurecr.io`.
+
+```yaml
+apiVersion: msi-acrpull.microsoft.com/v1beta1
+kind: AcrPullBinding
+metadata:
+  name: acrpulltest
+spec:
+  acrServer: veryimportantcr.azurecr.io
+  managedIdentityClientID: ""
+  managedIdentityResourceID: /subscriptions/712288dc-f816-4242-b73f-a0a87265dcc8/resourceGroups/my-identities/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-acr-puller
+```
+
+Once the custom resource deployed, you can deploy your application to pull images from the ACR. No changes to the application deployment yaml is needed.
+
 # How it works
 The architecture looks like below. As an user you will create a custom resource `ACRPullBinding`, which binds a managed identity (using client ID or resource ID) to an Azure container registry (using its FQDN). 
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ metadata:
   name: acrpulltest
 spec:
   acrServer: veryimportantcr.azurecr.io
-  managedIdentityClientID: ""
   managedIdentityResourceID: /subscriptions/712288dc-f816-4242-b73f-a0a87265dcc8/resourceGroups/my-identities/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-acr-puller
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ kubectl apply -f https://raw.githubusercontent.com/Azure/msi-acrpull/main/deploy
 # How to use
 > NOTE: following steps assumes you already have:
 > 1) An Kubernetes cluster, and have user assigned managed identities on node pool VMSS.
-> 1) An ACR, and the user assigned identity has `pull` permission on ACR.
+> 1) An ACR, and the user assigned identity has [AcrPull](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-roles#pull-image) role assigned on ACR.
 
-Once msi-acrpull installs to your cluster. All you need is to deploy a custom resource `AcrPullBinding` to the application namesapce to bind an user assigned identity to an ACR. Following sample specifies all pods using default service account in the namespace to use user managed identity `my-acr-puller` to pull image from `veryimportantcr.azurecr.io`.
+Once msi-acrpull is installed to your cluster, all you need is to deploy a custom resource `AcrPullBinding` to the application namesapce to bind an user assigned identity to an ACR. Following sample specifies all pods using default service account in the namespace to use user managed identity `my-acr-puller` to pull image from `veryimportantcr.azurecr.io`.
 
 ```yaml
 apiVersion: msi-acrpull.microsoft.com/v1beta1

--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ MSI ACR Pull enables deployments in a Kubernetes cluster to use any user assigne
 Run following command to install latest build from main branch. It will install the needed custom resource definition `ACRPullBinding` and deploy msi-acrpull controllers in `msi-acrpull-system` namespace.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/Azure/msi-acrpull/main/deploy/latest/crd.yaml
-kubectl apply -f https://raw.githubusercontent.com/Azure/msi-acrpull/main/deploy/latest/deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/Azure/msi-acrpull/main/deploy/latest/crd.yaml -f https://raw.githubusercontent.com/Azure/msi-acrpull/main/deploy/latest/deploy.yaml
 ```
 
 # How to use
-Once msi-acrpull installs to your cluster. All you need is to deploy a custom resource `ACRPullBinding` to the application namesapce to bind an user assigned identity to an ACR. Following sample specifies all pods in the namespace to use user managed identity `my-acr-puller` to pull image from `veryimportantcr.azurecr.io`.
+> NOTE: following steps assumes you already have:
+> 1) An Kubernetes cluster, and have user assigned managed identities on node pool VMSS.
+> 1) An ACR, and the user assigned identity has `pull` permission on ACR.
+
+Once msi-acrpull installs to your cluster. All you need is to deploy a custom resource `AcrPullBinding` to the application namesapce to bind an user assigned identity to an ACR. Following sample specifies all pods using default service account in the namespace to use user managed identity `my-acr-puller` to pull image from `veryimportantcr.azurecr.io`.
 
 ```yaml
 apiVersion: msi-acrpull.microsoft.com/v1beta1
@@ -23,7 +26,9 @@ spec:
   managedIdentityResourceID: /subscriptions/712288dc-f816-4242-b73f-a0a87265dcc8/resourceGroups/my-identities/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-acr-puller
 ```
 
-Once the custom resource deployed, you can deploy your application to pull images from the ACR. No changes to the application deployment yaml is needed.
+Once the custom resource deployed, you can deploy your application to pull images from the ACR. No changes to the application deployment yaml is needed. 
+
+> If the application pod uses a custom service account, then specify `serviceAccountName` property in AcrPullBinding spec.
 
 # How it works
 The architecture looks like below. As an user you will create a custom resource `ACRPullBinding`, which binds a managed identity (using client ID or resource ID) to an Azure container registry (using its FQDN). 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 
 # MSI ACR Pull
-MSI ACR Pull enables deployments in a Kubernetes cluster to use any user assigned managed identity to pull images from Azure container registry. With this, each application can use its own identity to pull container images.
+MSI ACR Pull enables deployments in a Kubernetes cluster to use any user assigned managed identity to pull images from Azure Container Registry. With this, each application can use its own identity to pull container images.
+
+# Install
+Run following command to install latest build from main branch. It will install the needed custom resource definition `ACRPullBinding` and deploy msi-acrpull controllers in `msi-acrpull-system` namespace.
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/Azure/msi-acrpull/main/deploy/latest/crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/Azure/msi-acrpull/main/deploy/latest/deploy.yaml
+```
 
 # How it works
 The architecture looks like below. As an user you will create a custom resource `ACRPullBinding`, which binds a managed identity (using client ID or resource ID) to an Azure container registry (using its FQDN). 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: msi-acrpull
-  newTag: latest
+  newName: mcr.microsoft.com/aks/msi-acrpull

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: mcr.microsoft.com/aks/msi-acrpull
+  newTag: v0.1.0-alpha

--- a/deploy/latest/crd.yaml
+++ b/deploy/latest/crd.yaml
@@ -1,0 +1,75 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+  creationTimestamp: null
+  name: acrpullbindings.msi-acrpull.microsoft.com
+spec:
+  group: msi-acrpull.microsoft.com
+  names:
+    kind: AcrPullBinding
+    listKind: AcrPullBindingList
+    plural: acrpullbindings
+    singular: acrpullbinding
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: AcrPullBinding is the Schema for the acrpullbindings API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AcrPullBindingSpec defines the desired state of AcrPullBinding
+          properties:
+            acrServer:
+              description: The full server name for the ACR. For example, test.azurecr.io
+              minLength: 0
+              type: string
+            managedIdentityClientID:
+              description: The Managed Identity client ID that is used to authenticate with ACR (specify one of ClientID or ResourceID)
+              type: string
+            managedIdentityResourceID:
+              description: The Managed Identity resource ID that is used to authenticate with ACR (if ClientID is specified, this is ignored)
+              type: string
+            serviceAccountName:
+              description: The Service Account to associate the image pull secret with. If this is not specified, the default Service Account of the namespace will be used.
+              type: string
+          required:
+          - acrServer
+          type: object
+        status:
+          description: AcrPullBindingStatus defines the observed state of AcrPullBinding
+          properties:
+            error:
+              description: Error message if there was an error updating the token.
+              type: string
+            lastTokenRefreshTime:
+              description: Information when was the last time the ACR token was refreshed.
+              format: date-time
+              type: string
+            tokenExpirationTime:
+              description: The expiration date of the current ACR token.
+              format: date-time
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/latest/deploy.yaml
+++ b/deploy/latest/deploy.yaml
@@ -1,0 +1,209 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: msi-acrpull-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: msi-acrpull-leader-election-role
+  namespace: msi-acrpull-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: msi-acrpull-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - msi-acrpull.microsoft.com
+  resources:
+  - acrpullbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - msi-acrpull.microsoft.com
+  resources:
+  - acrpullbindings/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: msi-acrpull-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: msi-acrpull-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: msi-acrpull-leader-election-rolebinding
+  namespace: msi-acrpull-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: msi-acrpull-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: msi-acrpull-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: msi-acrpull-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: msi-acrpull-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: msi-acrpull-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: msi-acrpull-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: msi-acrpull-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: msi-acrpull-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: msi-acrpull-controller-manager-metrics-service
+  namespace: msi-acrpull-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: msi-acrpull-controller-manager
+  namespace: msi-acrpull-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        command:
+        - /manager
+        image: mcr.microsoft.com/aks/msi-acrpull:latest
+        name: manager
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+      terminationGracePeriodSeconds: 10

--- a/deploy/latest/deploy.yaml
+++ b/deploy/latest/deploy.yaml
@@ -172,7 +172,7 @@ metadata:
   name: msi-acrpull-controller-manager
   namespace: msi-acrpull-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       control-plane: controller-manager
@@ -192,7 +192,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/deploy/latest/deploy.yaml
+++ b/deploy/latest/deploy.yaml
@@ -187,7 +187,7 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: mcr.microsoft.com/aks/msi-acrpull:latest
+        image: mcr.microsoft.com/aks/msi-acrpull:v0.1.0-alpha
         name: manager
         resources:
           limits:


### PR DESCRIPTION
Add a Makefile target to build deploy artifacts. With that the GH action can deploy the latest CRD and deployment for CI testing.

I used MCR latest tag for now and will move to msiacrpullci repo once it's public.