### PR TITLE
Add cache to Go build workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-
+    - uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+      
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
Add cache to Go build workflow. With the cache when there is no mod changes `go mod download` won't need download anything.

![image](https://user-images.githubusercontent.com/8466897/90369007-d7f53200-e01f-11ea-8c8f-4f14f4ae9cca.png)
