### PR TITLE
Custom ARM resource for sovereign clouds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
 
 pr: none
 
-pool: "AKS-Prod-Pool"
+pool: "AKS-Elastic-Prod-Pool"
 
 variables:
 - group: aks-prod-registry

--- a/controllers/acrpullbinding_controller_test.go
+++ b/controllers/acrpullbinding_controller_test.go
@@ -60,17 +60,17 @@ var _ = Describe("AcrPullBinding Controller Tests", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("Should use defaults when no parameters defined", func(){
+		It("Should use defaults when no parameters defined", func() {
 			mockCtrl := gomock.NewController(GinkgoT())
 			fakeAuth := mock_authorizer.NewMockInterface(mockCtrl)
 
 			reconciler := &AcrPullBindingReconciler{
-				Client: fake.NewFakeClientWithScheme(scheme.Scheme),
-				Log:    ctrl.Log.WithName("controllers").WithName("acrpullbinding-controller"),
-				Scheme: scheme.Scheme,
-				Auth: fakeAuth,
+				Client:                           fake.NewFakeClientWithScheme(scheme.Scheme),
+				Log:                              ctrl.Log.WithName("controllers").WithName("acrpullbinding-controller"),
+				Scheme:                           scheme.Scheme,
+				Auth:                             fakeAuth,
 				DefaultManagedIdentityResourceID: "defaultResourceID",
-				DefaultACRServer: "DefaultACRServer",
+				DefaultACRServer:                 "DefaultACRServer",
 			}
 			fakeAuth.EXPECT().AcquireACRAccessTokenWithResourceID(
 				gomock.Eq(reconciler.DefaultManagedIdentityResourceID),
@@ -88,7 +88,7 @@ var _ = Describe("AcrPullBinding Controller Tests", func() {
 			req := ctrl.Request{
 				NamespacedName: k8stypes.NamespacedName{
 					Namespace: "default",
-					Name: "test",
+					Name:      "test",
 				},
 			}
 			reconciler.Reconcile(req)

--- a/pkg/authorizer/token_retriever.go
+++ b/pkg/authorizer/token_retriever.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -14,7 +15,8 @@ import (
 )
 
 const (
-	armResource                     = "https://management.azure.com/"
+	defaultARMResource              = "https://management.azure.com/"
+	customARMResourceEnvVar         = "ARM_RESOURCE"
 	msiMetadataEndpoint             = "http://169.254.169.254/metadata/identity/oauth2/token"
 	defaultCacheExpirationInSeconds = 600
 )
@@ -79,7 +81,13 @@ func (tr *TokenRetriever) refreshToken(clientID, resourceID string) (types.Acces
 		parameters.Add("mi_res_id", resourceID)
 	}
 
-	parameters.Add("resource", armResource)
+	customARMResource := os.Getenv(customARMResourceEnvVar)
+	if customARMResource == "" {
+		parameters.Add("resource", defaultARMResource)
+	} else {
+		parameters.Add("resource", customARMResource)
+	}
+
 	parameters.Add("api-version", "2018-02-01")
 
 	msiEndpoint.RawQuery = parameters.Encode()


### PR DESCRIPTION
- For US government cloud and China cloud the ARM resource should be different so allowing it to be modified through env variable instead of hardcoding it
- Also change the agent pool because it is different now