### PR TITLE
If ResourceId has a duplicate slash it will fail to pull a Token from IMDS

### DIFF
--- a/controllers/acrpullbinding_controller.go
+++ b/controllers/acrpullbinding_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -147,12 +148,12 @@ func (r *AcrPullBindingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 
 func specOrDefault(r *AcrPullBindingReconciler, spec msiacrpullv1beta1.AcrPullBindingSpec) (string, string, string) {
 	msiClientID := spec.ManagedIdentityClientID
-	msiResourceID := spec.ManagedIdentityResourceID
+	msiResourceID := path.Clean(spec.ManagedIdentityResourceID)
 	acrServer := spec.AcrServer
 	if msiClientID == "" {
 		msiClientID = r.DefaultManagedIdentityClientID
 	}
-	if msiResourceID == "" {
+	if msiResourceID == "." {
 		msiResourceID = r.DefaultManagedIdentityResourceID
 	}
 	if acrServer == "" {

--- a/controllers/acrpullbinding_controller_test.go
+++ b/controllers/acrpullbinding_controller_test.go
@@ -346,6 +346,16 @@ var _ = Describe("AcrPullBinding Controller Tests", func() {
 		})
 	})
 
+	Context("specOrDefaultTest", func() {
+		It("should deduplicate double slash", func() {
+			reconciler := &AcrPullBindingReconciler{}
+			spec := msiacrpullv1beta1.AcrPullBindingSpec{
+				ManagedIdentityResourceID: "/resourcegroup//doubleslash/singleslash/",
+			}
+			_, msiResourceId, _ := specOrDefault(reconciler, spec)
+			Expect(msiResourceId).To(Equal("/resourcegroup/doubleslash/singleslash"))
+		})
+	})
 	Context("getServiceAccountName", func() {
 		It("Should get service account name", func() {
 			Expect(getServiceAccountName("")).To(Equal(defaultServiceAccountName))


### PR DESCRIPTION
Noticed that resource ID is essentially a path - if a double slash is passed in there is no dedupe and it will fail to grab the token from IMDS