### PR TITLE
controller: short-circuit after updating finalizer

### DIFF
--- a/internal/controller/acrpullbinding_controller_test.go
+++ b/internal/controller/acrpullbinding_controller_test.go
@@ -86,7 +86,7 @@ var _ = Describe("AcrPullBinding Controller Tests", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test",
 					Namespace:  "default",
-					Finalizers: []string{},
+					Finalizers: []string{"msi-acrpull.microsoft.com"},
 				},
 			}
 			err := reconciler.Create(context.TODO(), acrBinding)
@@ -174,7 +174,8 @@ var _ = Describe("AcrPullBinding Controller Tests", func() {
 			}
 			log := reconciler.Log.WithValues("acrpullbinding", "default")
 			ctx := context.Background()
-			err := reconciler.addFinalizer(ctx, acrBinding, log)
+			updated, err := reconciler.addFinalizer(ctx, acrBinding, log)
+			Expect(updated).To(BeTrue())
 			Expect(err).To(BeNil())
 			Expect(acrBinding.Finalizers).To(HaveLen(1))
 			Expect(acrBinding.Finalizers[0]).To(Equal("msi-acrpull.microsoft.com"))


### PR DESCRIPTION
It is accepted best-practice to only make one mutating API call per reconciliation loop, especially when changing resources that are under a WATCH and will trigger a further reconciliation, as the moment you keep reconciling an object after mutating it, not only are you working off of a stale cache of what the object looks like, but you're also delaying the next processing loop, which would work off of the correct state.

Here, we exit early if we needed to take corrective action to add a finalizer to an ACR pull binding that did not yet have one. The next reconciliation loop will handle the rest of the logic.