### PR TITLE
api/v1beta2: allow targetting custom identities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: $(CONTROLLER_GEN) ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd paths="./..." output:crd:artifacts:config=config/helm/templates
+	$(CONTROLLER_GEN) rbac:roleName=acrpull-controller crd paths="./..." output:dir=config/helm/templates output:crd:artifacts:config=config/helm/templates
+	mv config/helm/templates/role.yaml config/helm/templates/controller_role.yaml
 
 .PHONY: generate
 generate: $(CONTROLLER_GEN) mocks ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/api/v1beta2/acrpullbinding_types.go
+++ b/api/v1beta2/acrpullbinding_types.go
@@ -141,27 +141,49 @@ type ManagedIdentityAuth struct {
 	ResourceID string `json:"resourceID,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="(has(self.clientID) && has(self.tenantID)) || (!has(self.clientID) && !has(self.tenantID))", message="custom client and tenant identifiers must be provided together, if at all"
+
 type WorkloadIdentityAuth struct {
 	// +kubebuilder:validation:Required
 
 	// ServiceAccountName specifies the name of the service account
 	// that should be used when authenticating with WorkloadIdentity.
 	ServiceAccountName string `json:"serviceAccountRef,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:example="1b461305-28be-5271-beda-bd9fd2e24251"
+
+	// ClientID holds an optional client identifier of a federated identity.
+	// Specify this identifier if multiple identities are federated with the
+	// service account and the identity to use for image pulling is not the
+	// default identity stored in the service account's annotations. The
+	// client and tenant ID must be specified together.
+	ClientID string `json:"clientID,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:example="72f988bf-86f1-41af-91ab-2d7cd011db47"
+
+	// TenantID holds an optional tenant identifier of a federated identity.
+	// Specify this identifier if multiple identities are federated with the
+	// service account and the identity to use for image pulling is not the
+	// default identity stored in the service account's annotations. The
+	// client and tenant ID must be specified together.
+	TenantID string `json:"tenantID,omitempty"`
 }
 
 // AcrPullBindingStatus defines the observed state of AcrPullBinding
 type AcrPullBindingStatus struct {
-	// +optional
+	// +kubebuilder:validation:Optional
 
 	// Information when was the last time the ACR token was refreshed.
 	LastTokenRefreshTime *metav1.Time `json:"lastTokenRefreshTime,omitempty"`
 
-	// +optional
+	// +kubebuilder:validation:Optional
 
 	// The expiration date of the current ACR token.
 	TokenExpirationTime *metav1.Time `json:"tokenExpirationTime,omitempty"`
 
-	// +optional
+	// +kubebuilder:validation:Optional
 
 	// Error message if there was an error updating the token.
 	Error string `json:"error,omitempty"`

--- a/config/helm/templates/acrpull.microsoft.com_acrpullbindings.yaml
+++ b/config/helm/templates/acrpull.microsoft.com_acrpullbindings.yaml
@@ -136,12 +136,35 @@ spec:
                     description: WorkloadIdentity uses Azure Workload Identity to
                       authenticate with Azure.
                     properties:
+                      clientID:
+                        description: |-
+                          ClientID holds an optional client identifier of a federated identity.
+                          Specify this identifier if multiple identities are federated with the
+                          service account and the identity to use for image pulling is not the
+                          default identity stored in the service account's annotations. The
+                          client and tenant ID must be specified together.
+                        example: 1b461305-28be-5271-beda-bd9fd2e24251
+                        type: string
                       serviceAccountRef:
                         description: |-
                           ServiceAccountName specifies the name of the service account
                           that should be used when authenticating with WorkloadIdentity.
                         type: string
+                      tenantID:
+                        description: |-
+                          TenantID holds an optional tenant identifier of a federated identity.
+                          Specify this identifier if multiple identities are federated with the
+                          service account and the identity to use for image pulling is not the
+                          default identity stored in the service account's annotations. The
+                          client and tenant ID must be specified together.
+                        example: 72f988bf-86f1-41af-91ab-2d7cd011db47
+                        type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: custom client and tenant identifiers must be provided
+                        together, if at all
+                      rule: (has(self.clientID) && has(self.tenantID)) || (!has(self.clientID)
+                        && !has(self.tenantID))
                 type: object
                 x-kubernetes-validations:
                 - message: only one authentication type can be set

--- a/config/helm/templates/controller_role.yaml
+++ b/config/helm/templates/controller_role.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/internal/controller/acrpullbinding_v1beta2_controller_test.go
+++ b/internal/controller/acrpullbinding_v1beta2_controller_test.go
@@ -248,6 +248,66 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "workload identity binding with literal identifiers missing pull credential mints a new one",
+			acrBinding: &msiacrpullv1beta2.AcrPullBinding{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},
+				Spec: msiacrpullv1beta2.AcrPullBindingSpec{
+					ServiceAccountName: "delegate",
+					ACR: msiacrpullv1beta2.AcrConfiguration{
+						Server:      "registry.azurecr.io",
+						Scope:       "repository:testing:pull,push",
+						Environment: msiacrpullv1beta2.AzureEnvironmentPublicCloud,
+					},
+					Auth: msiacrpullv1beta2.AuthenticationMethod{
+						WorkloadIdentity: &msiacrpullv1beta2.WorkloadIdentityAuth{
+							ServiceAccountName: "delegate",
+							ClientID:           "client-id",
+							TenantID:           "tenant-id",
+						},
+					},
+				},
+			},
+			serviceAccount: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "delegate",
+					Annotations: map[string]string{
+						"azure.workload.identity/tenant-id": "other-tenant-id",
+						"azure.workload.identity/client-id": "other-client-id",
+					},
+				},
+			},
+			pullSecret: nil,
+			tokenStub:  workloadIdentityLiteralValidatingTokenStub(futureToken, nil),
+			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
+				createSecret: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+						Labels: map[string]string{
+							"acr.microsoft.com/binding": "binding",
+						},
+						Annotations: map[string]string{
+							"acr.microsoft.com/token.expiry":  longExpiry.Format(time.RFC3339),
+							"acr.microsoft.com/token.refresh": fakeClock.Now().Format(time.RFC3339),
+							"acr.microsoft.com/token.inputs":  "zrlombgy4mz11lkl9yxxi5n5sibq3cknbiekmkf7aju",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "acrpull.microsoft.com/v1beta2",
+								Kind:               "AcrPullBinding",
+								Name:               "binding",
+								Controller:         ptr.To(true),
+								BlockOwnerDeletion: ptr.To(true),
+							},
+						},
+					},
+					Type: corev1.SecretTypeDockerConfigJson,
+					Data: map[string][]byte{
+						".dockerconfigjson": []byte(`{"auths":{"registry.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
+					},
+				},
+			},
+		},
+		{
 			name: "workload identity binding referring to service account without workload identity errors",
 			acrBinding: &msiacrpullv1beta2.AcrPullBinding{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},
@@ -1256,6 +1316,32 @@ func workloadIdentityValidatingTokenStub(output azcore.AccessToken, outputError 
 				assert.Empty(t, cmp.Diff(spec, binding.Spec), "arm token request binding spec mismatch")
 				assert.Equal(t, serviceAccount.Annotations["azure.workload.identity/tenant-id"], tenantId, "arm token request tenant id mismatch")
 				assert.Equal(t, serviceAccount.Annotations["azure.workload.identity/client-id"], clientId, "arm token request client id mismatch")
+				assert.Equal(t, "fake-sa-token", serviceAccountToken, "arm token request service account token mismatch")
+				return azcore.AccessToken{Token: "fake-arm-token"}, outputError
+			}, func(ctx context.Context, armToken azcore.AccessToken, spec msiacrpullv1beta2.AcrConfiguration) (azcore.AccessToken, error) {
+				assert.Empty(t, cmp.Diff(spec, binding.Spec.ACR), "acr token exchange binding ACR spec mismatch")
+				assert.Equal(t, "fake-arm-token", armToken.Token, "acr token exchange arm token mismatch")
+				return output, outputError
+			}
+	}
+}
+
+func workloadIdentityLiteralValidatingTokenStub(output azcore.AccessToken, outputError error) func(*testing.T, *msiacrpullv1beta2.AcrPullBinding, *corev1.ServiceAccount) (ServiceAccountTokenMinter, armTokenFetcher, armAcrTokenExchanger) {
+	return func(t *testing.T, binding *msiacrpullv1beta2.AcrPullBinding, serviceAccount *corev1.ServiceAccount) (ServiceAccountTokenMinter, armTokenFetcher, armAcrTokenExchanger) {
+		return func(ctx context.Context, serviceAccountNamespace, serviceAccountName string) (*authenticationv1.TokenRequest, error) {
+				assert.Equal(t, serviceAccount.Namespace, serviceAccountNamespace, "token request service account namespace doesn't match service account object namespace")
+				assert.Equal(t, serviceAccount.Name, serviceAccountName, "token request service account name doesn't match service account object name")
+				assert.Equal(t, binding.Namespace, serviceAccountNamespace, "token request service account namespace doesn't match binding")
+				assert.Equal(t, binding.Spec.Auth.WorkloadIdentity.ServiceAccountName, serviceAccountName, "token request service account name doesn't match service account configured in binding")
+				return &authenticationv1.TokenRequest{
+					Status: authenticationv1.TokenRequestStatus{
+						Token: "fake-sa-token",
+					},
+				}, nil
+			}, func(ctx context.Context, spec msiacrpullv1beta2.AcrPullBindingSpec, tenantId, clientId, serviceAccountToken string) (azcore.AccessToken, error) {
+				assert.Empty(t, cmp.Diff(spec, binding.Spec), "arm token request binding spec mismatch")
+				assert.Equal(t, spec.Auth.WorkloadIdentity.TenantID, tenantId, "arm token request tenant id mismatch")
+				assert.Equal(t, spec.Auth.WorkloadIdentity.ClientID, clientId, "arm token request client id mismatch")
 				assert.Equal(t, "fake-sa-token", serviceAccountToken, "arm token request service account token mismatch")
 				return azcore.AccessToken{Token: "fake-arm-token"}, outputError
 			}, func(ctx context.Context, armToken azcore.AccessToken, spec msiacrpullv1beta2.AcrConfiguration) (azcore.AccessToken, error) {

--- a/test/infrastructure/aks.bicep
+++ b/test/infrastructure/aks.bicep
@@ -118,4 +118,17 @@ resource federatedCredentialScoped 'Microsoft.ManagedIdentity/userAssignedIdenti
   dependsOn: [federatedCredentialMutation]
 }
 
+resource federatedCredentialNonDefault 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2023-01-31' = {
+  name: guid(aks.id, pullerIdentity.id, 'nondefault')
+  parent: pullerIdentity
+  properties: {
+    audiences: [
+      'api://AzureCRTokenExchange'
+    ]
+    issuer: aks.properties.oidcIssuerProfile.issuerURL
+    subject: 'system:serviceaccount:v1beta2-wi-nondefault:sa'
+  }
+  dependsOn: [federatedCredentialScoped]
+}
+
 output aks string = aks.name


### PR DESCRIPTION
In environments where users have not annotated their service accounts with the default client/tenant ID to use, or where they have federated many identities to one service account, it is necessary to specity the client and tenant ID for auth with WI explicitly.