### PR TITLE
api: add printer columns for v1beta2 API

### DIFF
--- a/api/v1beta2/acrpullbinding_types.go
+++ b/api/v1beta2/acrpullbinding_types.go
@@ -194,6 +194,12 @@ type AcrPullBindingStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="Server",type="string",JSONPath=".spec.acr.server",description="FQDN for the ACR.",priority=0
+// +kubebuilder:printcolumn:name="Scope",type="string",JSONPath=".spec.acr.scope",description="Scope for the ACR token.",priority=1
+// +kubebuilder:printcolumn:name="Target",type="string",JSONPath=".spec.serviceAccountName",description="ServiceAccount to which the pull credentials are attached.",priority=0
+// +kubebuilder:printcolumn:name="Last Refresh",type="date",JSONPath=".status.lastTokenRefreshTime",description="Time the token was last refreshed.",priority=1
+// +kubebuilder:printcolumn:name="Expiration",type="date",JSONPath=".status.tokenExpirationTime",description="Time the current token expires.",priority=0
+// +kubebuilder:printcolumn:name="Error",type="string",JSONPath=".status.error",description="Errors encountered during token generation, if any.",priority=0
 
 // AcrPullBinding is the Schema for the acrpullbindings API
 type AcrPullBinding struct {

--- a/config/helm/templates/acrpull.microsoft.com_acrpullbindings.yaml
+++ b/config/helm/templates/acrpull.microsoft.com_acrpullbindings.yaml
@@ -17,7 +17,34 @@ spec:
     singular: acrpullbinding
   scope: Namespaced
   versions:
-  - name: v1beta2
+  - additionalPrinterColumns:
+    - description: FQDN for the ACR.
+      jsonPath: .spec.acr.server
+      name: Server
+      type: string
+    - description: Scope for the ACR token.
+      jsonPath: .spec.acr.scope
+      name: Scope
+      priority: 1
+      type: string
+    - description: ServiceAccount to which the pull credentials are attached.
+      jsonPath: .spec.serviceAccountName
+      name: Target
+      type: string
+    - description: Time the token was last refreshed.
+      jsonPath: .status.lastTokenRefreshTime
+      name: Last Refresh
+      priority: 1
+      type: date
+    - description: Time the current token expires.
+      jsonPath: .status.tokenExpirationTime
+      name: Expiration
+      type: date
+    - description: Errors encountered during token generation, if any.
+      jsonPath: .status.error
+      name: Error
+      type: string
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: AcrPullBinding is the Schema for the acrpullbindings API


### PR DESCRIPTION
Users should be able to tell at a glance what the pull binding is for and whether or not there were any errors in generating the token.

Before:

```
$ kubectl --kubeconfig test/_output/aks.kubeconfig get acrpullbinding --all-namespaces
NAMESPACE               NAME           AGE
v1beta2-msi-scoped      pull-binding   10d
v1beta2-wi-nondefault   pull-binding   10d
v1beta2-wi-scoped       pull-binding   10d
```

After:

```
$ kubectl --kubeconfig test/_output/aks.kubeconfig get acrpullbinding --all-namespaces
NAMESPACE               NAME           SERVER                     EXPIRATION   ERROR
v1beta2-msi-scoped      pull-binding   3j6vsfxh2xtv4.azurecr.io   12h          
v1beta2-wi-nondefault   pull-binding   3j6vsfxh2xtv4.azurecr.io   11h          
v1beta2-wi-scoped       pull-binding   3j6vsfxh2xtv4.azurecr.io   12h    
```

After, wide:

```
$ kubectl --kubeconfig test/_output/aks.kubeconfig get acrpullbinding --all-namespaces -o wide
NAMESPACE               NAME           SERVER                     SCOPE                   LAST REFRESH   EXPIRATION   ERROR
v1beta2-msi-scoped      pull-binding   3j6vsfxh2xtv4.azurecr.io   repository:alice:pull   13h            12h          
v1beta2-wi-nondefault   pull-binding   3j6vsfxh2xtv4.azurecr.io   repository:alice:pull   12h            11h          
v1beta2-wi-scoped       pull-binding   3j6vsfxh2xtv4.azurecr.io   repository:alice:pull   13h            12h          
```