### PR TITLE
vap: allow removing legacy pull tokens

### DIFF
--- a/config/helm/templates/validatingadmissionpolicies.yaml
+++ b/config/helm/templates/validatingadmissionpolicies.yaml
@@ -122,9 +122,9 @@ spec:
     - name: removedPullSecrets
       expression: "variables.previousPullSecretNames.filter(s, !(s in variables.pullSecretNames))"
     - name: onlyCorrectPullSecretsAdded
-      expression: "variables.addedPullSecrets.all(s, s.matches('^acr-pull-.{1,44}-[a-zA-Z0-9]{10}$'))"
+      expression: "variables.addedPullSecrets.all(s, s.matches('^acr-pull-.{1,44}-[a-zA-Z0-9]{10}$') || s.matches('-msi-acrpull-secret$'))"
     - name: onlyCorrectPullSecretsRemoved
-      expression: "variables.removedPullSecrets.all(s, s.matches('^acr-pull-.{1,44}-[a-zA-Z0-9]{10}$'))"
+      expression: "variables.removedPullSecrets.all(s, s.matches('^acr-pull-.{1,44}-[a-zA-Z0-9]{10}$') || s.matches('-msi-acrpull-secret$'))"
   validations:
     - expression: "variables.secretsUnchanged == true && variables.automountUnchanged == true && variables.onlyCorrectPullSecretsAdded == true && variables.onlyCorrectPullSecretsRemoved == true"
       messageExpression: "string(params.data.controllerServiceAccountName) + ' has failed to ' + string(request.operation) + ' service account ' + string(request.name) + ' in the ' + string(request.namespace) + ' namespace. The controller may only update service accounts to add or remove pull secrets that the controller manages.' + string(variables.automountUnchanged == true) + string(variables.automountUnchanged == true) + string(variables.onlyCorrectPullSecretsAdded == true) + string(variables.onlyCorrectPullSecretsRemoved == true)"


### PR DESCRIPTION
The legacy naming controller needs to be able to remove old pull credential names from the service account. We can remove this in the next release.