### PR TITLE
Dockerfile: use MCR for images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 as builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23-azurelinux3.0 as builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -21,9 +21,7 @@ COPY ./ ./
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
Not only do we benefit from owning the sources for the images we use to build this project, but we also run the risk of rate-limiting and outages on other registries impacting our ability to ship if we don't.