### PR TITLE
trim configmaps stuff

### DIFF
--- a/config/helm/templates/leader_election_role.yaml
+++ b/config/helm/templates/leader_election_role.yaml
@@ -1,27 +1,28 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: msi-acrpull-leader-election-role
-  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: acrpull
+    app.kubernetes.io/managed-by: Helm
+  name: acrpull-controller-leader-election
+  namespace: {{ .Values.namespace }}
 rules:
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "patch", "update"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: msi-acrpull-leader-election-rolebinding
-  namespace: {{ .Values.namespace }}
-  labels:
-    app.kubernetes.io/name: acrpull
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: msi-acrpull-leader-election-role
-subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: {{ .Values.namespace }}
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/config/helm/templates/leader_election_role.yaml
+++ b/config/helm/templates/leader_election_role.yaml
@@ -3,6 +3,8 @@ kind: Role
 metadata:
   name: msi-acrpull-leader-election-role
   namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: acrpull
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -12,7 +14,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: msi-acrpull-leader-election-rolebinding
-  namespace: msi-acrpull-system
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: acrpull
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -20,4 +24,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: default
-    namespace: msi-acrpull-system
+    namespace: {{ .Values.namespace }}

--- a/config/helm/templates/leader_election_role.yaml
+++ b/config/helm/templates/leader_election_role.yaml
@@ -1,40 +1,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  labels:
-    app.kubernetes.io/name: acrpull
-    app.kubernetes.io/managed-by: Helm
-  name: acrpull-controller-leader-election
-  namespace: {{ .Values.namespace }}
+  name: msi-acrpull-leader-election-role
+  namespace: msi-acrpull-system
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: msi-acrpull-leader-election-rolebinding
+  namespace: msi-acrpull-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: msi-acrpull-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: msi-acrpull-system

--- a/config/helm/templates/leader_election_role.yaml
+++ b/config/helm/templates/leader_election_role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: msi-acrpull-leader-election-role
-  namespace: msi-acrpull-system
+  namespace: {{ .Values.namespace }}
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]


### PR DESCRIPTION
Cleaning up the configmaps permissions, which were previously used for leader election in Kubernetes before the introduction of the leases API. This helps eliminate excessive permissions, reducing permission drift and ensuring stricter access control.

This is a PR from a branch of the repo itself, not my fork -- as requested by Steve. 