### PR TITLE
*: make secret names more easily assumable

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,7 +15,7 @@ jobs:
       AZURE_TENANT_ID: 72f988bf-86f1-41af-91ab-2d7cd011db47
       AZURE_SUBSCRIPTION_ID: 0cc1cafa-578f-4fa5-8d6b-ddfd8d82e6ea
       UNIQUE_INPUT: '${{ github.base_ref }}-${{ github.head_ref }}-${{ github.job }}-${{ github.run_id }}'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/README.md
+++ b/README.md
@@ -144,14 +144,6 @@ We recommend the following steps to migrate:
 1. Deploy the new `acrpull` controller and VAP.
 1. Upgrade `ACRPullBinding` objects from `v1beta1` to `v1beta2` at your own pace.
 
-### A note on upgrades
-
-If v0.1.5 is installed before v0.1.4 has had time to run to completion, the validating admission policies will not allow
-legacy credentials to be cleaned up. Please upgrade to v0.1.8 to unblock this flow, then follow steps starting from 2 above.
-
-It is **NOT SUPPORTED** to upgrade from v0.1.3 to v0.1.9 or higher. This will break the existing pull bindings on the cluster.
-Ensure that v0.1.4 or v0.1.8 are installed in between v0.1.3 and anything v0.1.9 or higher for a successful upgrade.
-
 ### A note on scopes
 
 The container registry spec does not allow for blanket "pull everything in this registry" permissions in a scope, so a

--- a/README.md
+++ b/README.md
@@ -27,6 +27,34 @@ either if they are assigned to the VMSS on which the `acrpull` controller is run
 identity federation to service accounts in the namespace. New deployments of `acrpull` should use the latter approach;
 the former remains as a back-stop for users who have not yet migrated.
 
+## A note on pull secrets
+
+When `Pod`s are created to fulfill `Deployment`s, `DaemonSet`s, _etc_, `pod.spec.imagePullSecrets` is defaulted from
+the pull secrets attached to the `ServiceAccount` referenced in `pod.spec.serviceAccount`, if present. This is a one-time
+action done during admission and the field is immutable afterword. This means that `ACRPullBinding` is, by default, racy.
+A valid series of events looks like this:
+
+1. a user creates an `ACRPullBinding` for a particular service account
+2. the `acrpull` controller creates the pull secret
+3. a user creates a `Deployment` referencing the service account
+4. the `Deployment` controller creates a `Pod`
+5. admission control defaults the list of `imagePullSecrets` on the `Pod` to the current list on the `ServiceAccount`, `[]`
+6. the `acrpull` controller attaches the pull secret to a service account
+7. the `Pod` is in a terminal state, as it references no pull secrets and will never be able to start
+
+This unfortunate series of events is by design and cannot be mitigated if the user expects to confer image pull credentials
+by attaching them to a service account. The only mitigation is to list the pull credential explicitly on the `PodSpec` and
+omit associating a `Pod` with a `ServiceAccount`, unless the association is necessary for some other reason.
+
+In order to make this easy, `acrpull` will mint pull credentials with names known _a priori_. v1beta1 `ACRPullBindings` will
+mint `Secrets` named `<binding-name>-msi-acrpull-secret`, as long as the binding name is short enough that the overall name
+is a valid `Secret` name. v1beta2 `ACRPullBindings` will mint `Secrets` named `acr-pull-<binding-name>`, with the same requirement
+for binding names.
+
+The suggested workflow is, therefore, to assume the name of the pull `Secret` that `acrpull` will generate and list it
+explicitly in the `PodSpec` of any associated `Pods`. If the secret does not yet exist when the `Pod` is scheduled, the
+`kubelet` will re-try the image pull later.
+
 ## Federated Workload Identities
 
 Once an AKS cluster is deployed, create some identity with permissions to interact with an ACR instance:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -89,7 +89,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	cleanupRequired := controller.LegacyPullSecretsPresent(pullBindings, secrets)
+	cleanupRequired := controller.LegacyPullSecretsPresentWithoutLabels(pullBindings, secrets)
 
 	// when we've already cleaned up all legacy secrets, we can filter our
 	// informers to only the set of secrets we create and manage

--- a/config/helm/templates/deployment.yaml
+++ b/config/helm/templates/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: acrpull
-  replicas: 2
+  replicas: {{ .Values.replicas }}
   template:
     metadata:
       labels:

--- a/config/helm/templates/namespace.yaml
+++ b/config/helm/templates/namespace.yaml
@@ -4,4 +4,4 @@ metadata:
   labels:
     app.kubernetes.io/name: acrpull
     app.kubernetes.io/managed-by: Helm
-  name: acrpull
+  name: {{ .Values.namespace }}

--- a/config/helm/templates/validatingadmissionpolicies.yaml
+++ b/config/helm/templates/validatingadmissionpolicies.yaml
@@ -74,12 +74,12 @@ spec:
     - name: matchesPreviousSecretType
       expression: "has(oldObject.metadata) ? oldObject.type == object.type : true"
     - name: hasLabel
-      expression: "has(object.metadata.labels) && ('acr.microsoft.com/binding' in object.metadata.labels)"
+      expression: "object.metadata.name.matches('-msi-acrpull-secret$') ? true : (has(object.metadata.labels) && ('acr.microsoft.com/binding' in object.metadata.?labels.orValue({})))"
     - name: matchesPreviousLabel
-      expression: "has(oldObject.metadata) ? oldObject.metadata.labels == object.metadata.labels : true"
+      expression: "object.metadata.name.matches('-msi-acrpull-secret$') ? true : (has(oldObject.metadata) ? oldObject.metadata.labels == object.metadata.labels : true)"
   validations:
     - expression: "variables.hasOwner == true && variables.matchesPreviousOwner == true && variables.hasSecretType == true && variables.matchesPreviousSecretType == true && variables.hasLabel == true && variables.matchesPreviousLabel == true"
-      messageExpression: "string(params.data.controllerServiceAccountName)  + ' has failed to ' +  string(request.operation) + ' secret with ' + string(object.type) + ' type ' + 'in the ' + string(request.namespace) + ' namespace. The controller can only create or update secrets that it owns, with the correct type and having the correct label.'"
+      messageExpression: "string(params.data.controllerServiceAccountName)  + ' has failed to ' +  string(request.operation) + ' secret with ' + string(object.type) + ' type ' + 'in the ' + string(request.namespace) + ' namespace. The controller can only create or update secrets that it owns, with the correct type and having the correct label.' + string(variables.hasOwner == true) + string(variables.matchesPreviousOwner == true) + string(variables.hasSecretType == true) + string(variables.matchesPreviousSecretType == true) + string(variables.hasLabel == true) + string(variables.matchesPreviousLabel == true )"
       reason: "Forbidden"
 ---
 # This policy will deny updates to serviceAccounts that do something other than changing the list of managed pull secrets.
@@ -122,9 +122,9 @@ spec:
     - name: removedPullSecrets
       expression: "variables.previousPullSecretNames.filter(s, !(s in variables.pullSecretNames))"
     - name: onlyCorrectPullSecretsAdded
-      expression: "variables.addedPullSecrets.all(s, s.matches('^acr-pull-.{1,44}-[a-zA-Z0-9]{10}$') || s.matches('-msi-acrpull-secret$'))"
+      expression: "variables.addedPullSecrets.all(s, s.matches('^acr-pull-') || s.matches('-msi-acrpull-secret$'))"
     - name: onlyCorrectPullSecretsRemoved
-      expression: "variables.removedPullSecrets.all(s, s.matches('^acr-pull-.{1,44}-[a-zA-Z0-9]{10}$') || s.matches('-msi-acrpull-secret$'))"
+      expression: "variables.removedPullSecrets.all(s, s.matches('^acr-pull-') || s.matches('-msi-acrpull-secret$'))"
   validations:
     - expression: "variables.secretsUnchanged == true && variables.automountUnchanged == true && variables.onlyCorrectPullSecretsAdded == true && variables.onlyCorrectPullSecretsRemoved == true"
       messageExpression: "string(params.data.controllerServiceAccountName) + ' has failed to ' + string(request.operation) + ' service account ' + string(request.name) + ' in the ' + string(request.namespace) + ' namespace. The controller may only update service accounts to add or remove pull secrets that the controller manages.' + string(variables.automountUnchanged == true) + string(variables.automountUnchanged == true) + string(variables.onlyCorrectPullSecretsAdded == true) + string(variables.onlyCorrectPullSecretsRemoved == true)"

--- a/config/helm/templates/validatingadmissionpolicies.yaml
+++ b/config/helm/templates/validatingadmissionpolicies.yaml
@@ -122,9 +122,9 @@ spec:
     - name: removedPullSecrets
       expression: "variables.previousPullSecretNames.filter(s, !(s in variables.pullSecretNames))"
     - name: onlyCorrectPullSecretsAdded
-      expression: "variables.addedPullSecrets.all(s, s.matches('^acr-pull-.{1,44}-[a-zA-Z0-9]{10}$'))"
+      expression: "variables.addedPullSecrets.all(s, s.matches('^acr-pull-.{1,44}-[a-zA-Z0-9]{10}$') || s.matches('-msi-acrpull-secret$'))"
     - name: onlyCorrectPullSecretsRemoved
-      expression: "variables.removedPullSecrets.all(s, s.matches('^acr-pull-.{1,44}-[a-zA-Z0-9]{10}$'))"
+      expression: "variables.removedPullSecrets.all(s, s.matches('^acr-pull-.{1,44}-[a-zA-Z0-9]{10}$') || s.matches('-msi-acrpull-secret$'))"
   validations:
     - expression: "variables.secretsUnchanged == true && variables.automountUnchanged == true && variables.onlyCorrectPullSecretsAdded == true && variables.onlyCorrectPullSecretsRemoved == true"
       messageExpression: "string(params.data.controllerServiceAccountName) + ' has failed to ' + string(request.operation) + ' service account ' + string(request.name) + ' in the ' + string(request.namespace) + ' namespace. The controller may only update service accounts to add or remove pull secrets that the controller manages.' + string(variables.automountUnchanged == true) + string(variables.automountUnchanged == true) + string(variables.onlyCorrectPullSecretsAdded == true) + string(variables.onlyCorrectPullSecretsRemoved == true)"

--- a/config/helm/values.yaml
+++ b/config/helm/values.yaml
@@ -1,5 +1,6 @@
 namespace: acrpull
 image: registry/image:tag
+replicas: 2
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/internal/controller/acrpullbinding_controller.go
+++ b/internal/controller/acrpullbinding_controller.go
@@ -255,6 +255,10 @@ func pullSecretName(acrBindingName string) string {
 	return pullSecretNamePrefix + suffix + "-" + base36sha224([]byte(acrBindingName))[:10]
 }
 
+func legacySecretName(acrBindingName string) string {
+	return fmt.Sprintf("%s-msi-acrpull-secret", acrBindingName)
+}
+
 func newPullSecret(acrBinding client.Object,
 	dockerConfig string, scheme *runtime.Scheme, expiry time.Time, now func() time.Time, inputHash string) *corev1.Secret {
 

--- a/internal/controller/acrpullbinding_v1beta2_controller_test.go
+++ b/internal/controller/acrpullbinding_v1beta2_controller_test.go
@@ -47,7 +47,7 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 		name                       string
 		acrBinding                 *msiacrpullv1beta2.AcrPullBinding
 		serviceAccount             *corev1.ServiceAccount
-		pullSecret                 *corev1.Secret
+		pullSecrets                []corev1.Secret
 		referencingServiceAccounts []corev1.ServiceAccount
 
 		tokenStub func(*testing.T, *msiacrpullv1beta2.AcrPullBinding, *corev1.ServiceAccount) (ServiceAccountTokenMinter, armTokenFetcher, armAcrTokenExchanger)
@@ -106,12 +106,12 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
 			},
-			pullSecret: nil,
-			tokenStub:  managedIdentityValidatingTokenStub(futureToken, nil),
+			pullSecrets: nil,
+			tokenStub:   managedIdentityValidatingTokenStub(futureToken, nil),
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				createSecret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+						Namespace: "ns", Name: "acr-pull-binding",
 						Labels: map[string]string{
 							"acr.microsoft.com/binding": "binding",
 						},
@@ -158,12 +158,12 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
 			},
-			pullSecret: nil,
-			tokenStub:  managedIdentityValidatingTokenStub(futureToken, nil),
+			pullSecrets: nil,
+			tokenStub:   managedIdentityValidatingTokenStub(futureToken, nil),
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				createSecret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+						Namespace: "ns", Name: "acr-pull-binding",
 						Labels: map[string]string{
 							"acr.microsoft.com/binding": "binding",
 						},
@@ -216,12 +216,12 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 					},
 				},
 			},
-			pullSecret: nil,
-			tokenStub:  workloadIdentityValidatingTokenStub(futureToken, nil),
+			pullSecrets: nil,
+			tokenStub:   workloadIdentityValidatingTokenStub(futureToken, nil),
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				createSecret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+						Namespace: "ns", Name: "acr-pull-binding",
 						Labels: map[string]string{
 							"acr.microsoft.com/binding": "binding",
 						},
@@ -276,12 +276,12 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 					},
 				},
 			},
-			pullSecret: nil,
-			tokenStub:  workloadIdentityLiteralValidatingTokenStub(futureToken, nil),
+			pullSecrets: nil,
+			tokenStub:   workloadIdentityLiteralValidatingTokenStub(futureToken, nil),
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				createSecret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+						Namespace: "ns", Name: "acr-pull-binding",
 						Labels: map[string]string{
 							"acr.microsoft.com/binding": "binding",
 						},
@@ -328,8 +328,8 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
 			},
-			pullSecret: nil,
-			tokenStub:  workloadIdentityValidatingTokenStub(futureToken, nil),
+			pullSecrets: nil,
+			tokenStub:   workloadIdentityValidatingTokenStub(futureToken, nil),
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				updatePullBindingStatus: &msiacrpullv1beta2.AcrPullBinding{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},
@@ -373,8 +373,8 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
 			},
-			pullSecret: nil,
-			tokenStub:  managedIdentityValidatingTokenStub(azcore.AccessToken{}, errors.New("oops")),
+			pullSecrets: nil,
+			tokenStub:   managedIdentityValidatingTokenStub(azcore.AccessToken{}, errors.New("oops")),
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				updatePullBindingStatus: &msiacrpullv1beta2.AcrPullBinding{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},
@@ -418,9 +418,9 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
 			},
-			pullSecret: &corev1.Secret{
+			pullSecrets: []corev1.Secret{{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+					Namespace: "ns", Name: "acr-pull-binding",
 					Labels: map[string]string{
 						"acr.microsoft.com/binding": "binding",
 					},
@@ -443,11 +443,11 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				Data: map[string][]byte{
 					".dockerconfigjson": []byte(`{"auths":{"registry.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
 				},
-			},
+			}},
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				updateServiceAccount: &corev1.ServiceAccount{
 					ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
-					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
 				},
 			},
 		},
@@ -471,11 +471,11 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			},
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
-				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
 			},
-			pullSecret: &corev1.Secret{
+			pullSecrets: []corev1.Secret{{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+					Namespace: "ns", Name: "acr-pull-binding",
 					Labels: map[string]string{
 						"acr.microsoft.com/binding": "binding",
 					},
@@ -498,7 +498,7 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				Data: map[string][]byte{
 					".dockerconfigjson": []byte(`{"auths":{"registry.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
 				},
-			},
+			}},
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				updatePullBindingStatus: &msiacrpullv1beta2.AcrPullBinding{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},
@@ -546,11 +546,11 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			},
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
-				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
 			},
-			pullSecret: &corev1.Secret{
+			pullSecrets: []corev1.Secret{{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+					Namespace: "ns", Name: "acr-pull-binding",
 					Labels: map[string]string{
 						"acr.microsoft.com/binding": "binding",
 					},
@@ -573,12 +573,12 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				Data: map[string][]byte{
 					".dockerconfigjson": []byte(`{"auths":{"registry.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYyMTQzMDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.pt3Ra4QKcq7mHX3Qp9-0vzpzQKooPJmviQLWazhlcgHjtnf-QL3ZZYVy1F06ExmznYbtU1ADGOBuhtn94ORezYZ5Dg3eSS5hSpuSnJdpGQlkzLxsfyFUszKvKraqQ72hcRZ5kYkRd9dMT-yGphMoIqP3crfrzFR4ZIwf0JBMxiS_iNIvi7RHpg0lBLDZdP739lNQ6oY-O76H_SuYbgJ7HP0nssVy0DlQF6HT9X6Qq1gTCxuK28Juo2yDeTSaagjihgXeUc4zH2cMKz6f5deoIr3i7BNMuXVHOyXeEcShohHmfUFAAmr_LiotZsTeEXVaMkaoRFlCBb2bv2lM9PzFyw","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXlNVFF6TURVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLnB0M1JhNFFLY3E3bUhYM1FwOS0wdnpwelFLb29QSm12aVFMV2F6aGxjZ0hqdG5mLVFMM1paWVZ5MUYwNkV4bXpuWWJ0VTFBREdPQnVodG45NE9SZXpZWjVEZzNlU1M1aFNwdVNuSmRwR1Fsa3pMeHNmeUZVc3pLdktyYXFRNzJoY1JaNWtZa1JkOWRNVC15R3BoTW9JcVAzY3JmcnpGUjRaSXdmMEpCTXhpU19pTkl2aTdSSHBnMGxCTERaZFA3MzlsTlE2b1ktTzc2SF9TdVliZ0o3SFAwbnNzVnkwRGxRRjZIVDlYNlFxMWdUQ3h1SzI4SnVvMnlEZVRTYWFnamloZ1hlVWM0ekgyY01LejZmNWRlb0lyM2k3Qk5NdVhWSE95WGVFY1Nob2hIbWZVRkFBbXJfTGlvdFpzVGVFWFZhTWthb1JGbENCYjJidjJsTTlQekZ5dw=="}}}`),
 				},
-			},
+			}},
 			tokenStub: managedIdentityValidatingTokenStub(futureToken, nil),
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				updateSecret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+						Namespace: "ns", Name: "acr-pull-binding",
 						Labels: map[string]string{
 							"acr.microsoft.com/binding": "binding",
 						},
@@ -628,11 +628,11 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			},
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
-				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
 			},
-			pullSecret: &corev1.Secret{
+			pullSecrets: []corev1.Secret{{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+					Namespace: "ns", Name: "acr-pull-binding",
 					Labels: map[string]string{
 						"acr.microsoft.com/binding": "binding",
 					},
@@ -655,7 +655,7 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				Data: map[string][]byte{
 					".dockerconfigjson": []byte(`{"auths":{"registry.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
 				},
-			},
+			}},
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				updatePullBindingStatus: &msiacrpullv1beta2.AcrPullBinding{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},
@@ -675,6 +675,82 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 					Status: msiacrpullv1beta2.AcrPullBindingStatus{
 						LastTokenRefreshTime: &metav1.Time{Time: fakeClock.Now()},
 						TokenExpirationTime:  &metav1.Time{Time: longExpiry},
+					},
+				},
+			},
+		},
+		{
+			name: "everything up-to-date, remove extraneous pull secret",
+			acrBinding: &msiacrpullv1beta2.AcrPullBinding{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},
+				Spec: msiacrpullv1beta2.AcrPullBindingSpec{
+					ServiceAccountName: "delegate",
+					ACR: msiacrpullv1beta2.AcrConfiguration{
+						Server:      "registry.azurecr.io",
+						Scope:       "repository:testing:pull,push",
+						Environment: msiacrpullv1beta2.AzureEnvironmentPublicCloud,
+					},
+					Auth: msiacrpullv1beta2.AuthenticationMethod{
+						ManagedIdentity: &msiacrpullv1beta2.ManagedIdentityAuth{
+							ClientID: "client-id",
+						},
+					},
+				},
+				Status: msiacrpullv1beta2.AcrPullBindingStatus{
+					LastTokenRefreshTime: &metav1.Time{Time: fakeClock.Now()},
+					TokenExpirationTime:  &metav1.Time{Time: longExpiry},
+				},
+			},
+			serviceAccount: &corev1.ServiceAccount{
+				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
+			},
+			referencingServiceAccounts: []corev1.ServiceAccount{
+				{
+					ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
+				},
+			},
+			pullSecrets: []corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "acr-pull-binding",
+					Labels: map[string]string{
+						"acr.microsoft.com/binding": "binding",
+					},
+					Annotations: map[string]string{
+						"acr.microsoft.com/token.expiry":  longExpiry.Format(time.RFC3339),
+						"acr.microsoft.com/token.refresh": fakeClock.Now().Format(time.RFC3339),
+						"acr.microsoft.com/token.inputs":  "bznn8knczhrdktghbm88h4ock013v94i8e8cslwlrob",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "acrpull.microsoft.com/v1beta2",
+							Kind:               "AcrPullBinding",
+							Name:               "binding",
+							Controller:         ptr.To(true),
+							BlockOwnerDeletion: ptr.To(true),
+						},
+					},
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{"auths":{"registry.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "acr-pull-binding-other",
+					Labels: map[string]string{
+						"acr.microsoft.com/binding": "binding",
+					},
+				},
+			}},
+			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
+				deleteSecret: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns", Name: "acr-pull-binding-other",
+						Labels: map[string]string{
+							"acr.microsoft.com/binding": "binding",
+						},
 					},
 				},
 			},
@@ -703,17 +779,17 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			},
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
-				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
 			},
 			referencingServiceAccounts: []corev1.ServiceAccount{
 				{
 					ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
-					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
 				},
 			},
-			pullSecret: &corev1.Secret{
+			pullSecrets: []corev1.Secret{{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+					Namespace: "ns", Name: "acr-pull-binding",
 					Labels: map[string]string{
 						"acr.microsoft.com/binding": "binding",
 					},
@@ -736,7 +812,7 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				Data: map[string][]byte{
 					".dockerconfigjson": []byte(`{"auths":{"registry.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
 				},
-			},
+			}},
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				noop: &msiacrpullv1beta2.AcrPullBinding{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},
@@ -777,12 +853,12 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			referencingServiceAccounts: []corev1.ServiceAccount{
 				{
 					ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
-					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
 				},
 			},
-			pullSecret: &corev1.Secret{
+			pullSecrets: []corev1.Secret{{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+					Namespace: "ns", Name: "acr-pull-binding",
 					Labels: map[string]string{
 						"acr.microsoft.com/binding": "binding",
 					},
@@ -805,7 +881,7 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				Data: map[string][]byte{
 					".dockerconfigjson": []byte(`{"auths":{"registry.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
 				},
-			},
+			}},
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				updateServiceAccount: &corev1.ServiceAccount{
 					ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
@@ -837,11 +913,11 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			},
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
-				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
 			},
-			pullSecret: &corev1.Secret{
+			pullSecrets: []corev1.Secret{{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+					Namespace: "ns", Name: "acr-pull-binding",
 					Labels: map[string]string{
 						"acr.microsoft.com/binding": "binding",
 					},
@@ -864,12 +940,12 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				Data: map[string][]byte{
 					".dockerconfigjson": []byte(`{"auths":{"registry.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
 				},
-			},
+			}},
 			tokenStub: managedIdentityValidatingTokenStub(otherToken, nil),
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				updateSecret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+						Namespace: "ns", Name: "acr-pull-binding",
 						Labels: map[string]string{
 							"acr.microsoft.com/binding": "binding",
 						},
@@ -919,11 +995,11 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			},
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
-				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
 			},
-			pullSecret: &corev1.Secret{
+			pullSecrets: []corev1.Secret{{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+					Namespace: "ns", Name: "acr-pull-binding",
 					Labels: map[string]string{
 						"acr.microsoft.com/binding": "binding",
 					},
@@ -946,12 +1022,12 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				Data: map[string][]byte{
 					".dockerconfigjson": []byte(`{"auths":{"somewhere.else.biz":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
 				},
-			},
+			}},
 			tokenStub: managedIdentityValidatingTokenStub(otherToken, nil),
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				updateSecret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+						Namespace: "ns", Name: "acr-pull-binding",
 						Labels: map[string]string{
 							"acr.microsoft.com/binding": "binding",
 						},
@@ -1001,11 +1077,11 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			},
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
-				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
 			},
-			pullSecret: &corev1.Secret{
+			pullSecrets: []corev1.Secret{{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+					Namespace: "ns", Name: "acr-pull-binding",
 					Labels: map[string]string{
 						"acr.microsoft.com/binding": "binding",
 					},
@@ -1028,12 +1104,12 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				Data: map[string][]byte{
 					".dockerconfigjson": []byte(`{"auths":{"somewhere.else.biz":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
 				},
-			},
+			}},
 			tokenStub: managedIdentityValidatingTokenStub(otherToken, nil),
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				updateSecret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+						Namespace: "ns", Name: "acr-pull-binding",
 						Labels: map[string]string{
 							"acr.microsoft.com/binding": "binding",
 						},
@@ -1087,11 +1163,11 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			},
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
-				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
 			},
-			pullSecret: &corev1.Secret{
+			pullSecrets: []corev1.Secret{{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+					Namespace: "ns", Name: "acr-pull-binding",
 					Labels: map[string]string{
 						"acr.microsoft.com/binding": "binding",
 					},
@@ -1114,7 +1190,7 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				Data: map[string][]byte{
 					".dockerconfigjson": []byte(`{"auths":{"registry.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
 				},
-			},
+			}},
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				updateServiceAccount: &corev1.ServiceAccount{
 					ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
@@ -1152,9 +1228,9 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
 				ImagePullSecrets: []corev1.LocalObjectReference{},
 			},
-			pullSecret: &corev1.Secret{
+			pullSecrets: []corev1.Secret{{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+					Namespace: "ns", Name: "acr-pull-binding",
 					Labels: map[string]string{
 						"acr.microsoft.com/binding": "binding",
 					},
@@ -1177,11 +1253,11 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				Data: map[string][]byte{
 					".dockerconfigjson": []byte(`{"auths":{"registry.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
 				},
-			},
+			}},
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				deleteSecret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "ns", Name: "acr-pull-binding-37d7ayn69u",
+						Namespace: "ns", Name: "acr-pull-binding",
 						Labels: map[string]string{
 							"acr.microsoft.com/binding": "binding",
 						},
@@ -1237,7 +1313,7 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
 				ImagePullSecrets: []corev1.LocalObjectReference{},
 			},
-			pullSecret: nil,
+			pullSecrets: nil,
 			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
 				updatePullBinding: &msiacrpullv1beta2.AcrPullBinding{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1284,7 +1360,7 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 				TTLRotationFraction:         0.5,
 			})
 
-			output := controller.reconcile(context.Background(), logger, testCase.acrBinding, testCase.serviceAccount, testCase.pullSecret, testCase.referencingServiceAccounts)
+			output := controller.reconcile(context.Background(), logger, testCase.acrBinding, testCase.serviceAccount, testCase.pullSecrets, testCase.referencingServiceAccounts)
 			if diff := cmp.Diff(testCase.output, output, cmp.AllowUnexported(action[*msiacrpullv1beta2.AcrPullBinding]{})); diff != "" {
 				t.Errorf("-want, +got:\n%s", diff)
 			}

--- a/internal/controller/generic_controller.go
+++ b/internal/controller/generic_controller.go
@@ -15,38 +15,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
-
-const (
-	serviceAccountField   = ".spec.serviceAccountName"
-	imagePullSecretsField = ".imagePullSecrets"
-)
-
-func indexPullBindingByServiceAccount(object crclient.Object) []string {
-	acrPullBinding, ok := object.(*msiacrpullv1beta1.AcrPullBinding)
-	if !ok {
-		return nil
-	}
-
-	return []string{getServiceAccountName(acrPullBinding.Spec.ServiceAccountName)}
-}
-
-func enqueuePullBindingsForServiceAccount(mgr ctrl.Manager) func(ctx context.Context, object crclient.Object) []reconcile.Request {
-	return func(ctx context.Context, object crclient.Object) []reconcile.Request {
-		var pullBindings msiacrpullv1beta1.AcrPullBindingList
-		if err := mgr.GetClient().List(ctx, &pullBindings, crclient.InNamespace(object.GetNamespace()), crclient.MatchingFields{serviceAccountField: object.GetName()}); err != nil {
-			return nil
-		}
-		var requests []reconcile.Request
-		for _, pullBinding := range pullBindings.Items {
-			requests = append(requests, reconcile.Request{
-				NamespacedName: crclient.ObjectKeyFromObject(&pullBinding),
-			})
-		}
-		return requests
-	}
-}
 
 // genericReconciler reconciles AcrPullBindings
 type genericReconciler[O pullBinding] struct {

--- a/internal/controller/generic_controller.go
+++ b/internal/controller/generic_controller.go
@@ -29,6 +29,7 @@ type genericReconciler[O pullBinding] struct {
 	RemoveFinalizer func(O, string) O
 
 	GetServiceAccountName func(O) string
+	GetPullSecretName     func(O) string
 	GetInputsHash         func(O) string
 
 	CreatePullCredential func(context.Context, O, *corev1.ServiceAccount) (string, time.Time, error)
@@ -71,34 +72,39 @@ func (r *genericReconciler[O]) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
-	expectedPullSecretName := pullSecretName(acrBinding.GetName())
-	pullSecret := &corev1.Secret{}
-	if err := r.Client.Get(ctx, k8stypes.NamespacedName{
-		Namespace: req.Namespace,
-		Name:      expectedPullSecretName,
-	}, pullSecret); err != nil {
-		if !apierrors.IsNotFound(err) {
-			msg := "failed to get pull secret"
-			logger.Error(err, msg)
-			return ctrl.Result{}, fmt.Errorf("%s: %w", msg, err)
-		} else {
-			pullSecret = nil
-		}
-	}
-
-	var referencingServiceAccounts corev1.ServiceAccountList
-	if err := r.Client.List(ctx, &referencingServiceAccounts, crclient.InNamespace(acrBinding.GetNamespace()), crclient.MatchingFields{imagePullSecretsField: expectedPullSecretName}); err != nil {
-		msg := "failed to fetch service accounts referencing pull secret"
+	var pullSecrets corev1.SecretList
+	if err := r.Client.List(ctx, &pullSecrets, crclient.InNamespace(acrBinding.GetNamespace()), crclient.MatchingFields{pullBindingField: acrBinding.GetName()}); err != nil {
+		msg := "failed to fetch pull secrets referencing pull binding"
 		logger.Error(err, msg)
 		return ctrl.Result{}, fmt.Errorf("%s: %w", msg, err)
 	}
 
-	action := r.reconcile(ctx, logger, acrBinding, serviceAccount, pullSecret, referencingServiceAccounts.Items)
+	var pullSecretNames []string
+	if len(pullSecrets.Items) == 0 {
+		pullSecretNames = append(pullSecretNames, r.GetPullSecretName(acrBinding))
+	} else {
+		for _, pullSecret := range pullSecrets.Items {
+			pullSecretNames = append(pullSecretNames, pullSecret.ObjectMeta.Name)
+		}
+	}
+
+	var referencingServiceAccounts []corev1.ServiceAccount
+	for _, pullSecret := range pullSecretNames {
+		var serviceAccountList corev1.ServiceAccountList
+		if err := r.Client.List(ctx, &serviceAccountList, crclient.InNamespace(acrBinding.GetNamespace()), crclient.MatchingFields{imagePullSecretsField: pullSecret}); err != nil {
+			msg := "failed to fetch service accounts referencing pull secret"
+			logger.Error(err, msg)
+			return ctrl.Result{}, fmt.Errorf("%s: %w", msg, err)
+		}
+		referencingServiceAccounts = append(referencingServiceAccounts, serviceAccountList.Items...)
+	}
+
+	action := r.reconcile(ctx, logger, acrBinding, serviceAccount, pullSecrets.Items, referencingServiceAccounts)
 
 	return action.execute(ctx, logger, r.Client, r.RequeueAfter(r.now))
 }
 
-func (r *genericReconciler[O]) reconcile(ctx context.Context, logger logr.Logger, acrBinding O, serviceAccount *corev1.ServiceAccount, pullSecret *corev1.Secret, referencingServiceAccounts []corev1.ServiceAccount) *action[O] {
+func (r *genericReconciler[O]) reconcile(ctx context.Context, logger logr.Logger, acrBinding O, serviceAccount *corev1.ServiceAccount, pullSecrets []corev1.Secret, referencingServiceAccounts []corev1.ServiceAccount) *action[O] {
 	// examine DeletionTimestamp to determine if acr pull binding is under deletion
 	if acrBinding.GetDeletionTimestamp().IsZero() {
 		// the object is not being deleted, so if it does not have our finalizer,
@@ -109,7 +115,7 @@ func (r *genericReconciler[O]) reconcile(ctx context.Context, logger logr.Logger
 		}
 	} else {
 		// the object is being deleted, do cleanup as necessary
-		return r.cleanUp(acrBinding, serviceAccount, pullSecret, logger)
+		return r.cleanUp(acrBinding, serviceAccount, pullSecrets, logger)
 	}
 
 	// if the user changed which service account should be bound to this credential, we need to
@@ -120,7 +126,7 @@ func (r *genericReconciler[O]) reconcile(ctx context.Context, logger logr.Logger
 	for _, extraneous := range extraneousServiceAccounts {
 		updated := extraneous.DeepCopy()
 		updated.ImagePullSecrets = slices.DeleteFunc(updated.ImagePullSecrets, func(reference corev1.LocalObjectReference) bool {
-			return reference.Name == pullSecretName(acrBinding.GetName())
+			return reference.Name == r.GetPullSecretName(acrBinding)
 		})
 		if len(updated.ImagePullSecrets) != len(extraneous.ImagePullSecrets) {
 			logger.WithValues("serviceAccount", crclient.ObjectKeyFromObject(&extraneous).String()).Info("updating service account to remove image pull secret")
@@ -134,6 +140,13 @@ func (r *genericReconciler[O]) reconcile(ctx context.Context, logger logr.Logger
 		return &action[O]{updatePullBindingStatus: r.UpdateStatusError(acrBinding, err)}
 	}
 
+	expectedPullSecretName := r.GetPullSecretName(acrBinding)
+	var pullSecret *corev1.Secret
+	for _, secret := range pullSecrets {
+		if secret.Name == expectedPullSecretName {
+			pullSecret = &secret
+		}
+	}
 	inputHash := r.GetInputsHash(acrBinding)
 	pullSecretMissing := pullSecret == nil
 	pullSecretNeedsRefresh := !pullSecretMissing && r.NeedsRefresh(r.Logger, pullSecret, r.now)
@@ -147,7 +160,7 @@ func (r *genericReconciler[O]) reconcile(ctx context.Context, logger logr.Logger
 			return &action[O]{updatePullBindingStatus: r.UpdateStatusError(acrBinding, err.Error())}
 		}
 
-		newSecret := newPullSecret(acrBinding, dockerConfig, r.Scheme, expiresOn, r.now, inputHash)
+		newSecret := newPullSecret(acrBinding, r.GetPullSecretName(acrBinding), dockerConfig, r.Scheme, expiresOn, r.now, inputHash)
 		logger = logger.WithValues("secret", crclient.ObjectKeyFromObject(newSecret).String())
 		if pullSecret == nil {
 			logger.Info("creating pull credential secret")
@@ -169,11 +182,20 @@ func (r *genericReconciler[O]) reconcile(ctx context.Context, logger logr.Logger
 		return &action[O]{updateServiceAccount: updated}
 	}
 
+	// clean up any extraneous pull secrets that refer to this binding
+	for _, secret := range pullSecrets {
+		if secret.ObjectMeta.Name != expectedPullSecretName {
+			deleted := secret.DeepCopy()
+			logger.WithValues("secret", crclient.ObjectKeyFromObject(deleted).String()).Info("cleaning up extraneous pull credential")
+			return &action[O]{deleteSecret: deleted}
+		}
+	}
+
 	return r.setSuccessStatus(logger, acrBinding, pullSecret)
 }
 
 func (r *genericReconciler[O]) cleanUp(acrBinding O,
-	serviceAccount *corev1.ServiceAccount, pullSecret *corev1.Secret, log logr.Logger) *action[O] {
+	serviceAccount *corev1.ServiceAccount, pullSecrets []corev1.Secret, log logr.Logger) *action[O] {
 	if slices.Contains(acrBinding.GetFinalizers(), msiAcrPullFinalizerName) {
 		// our finalizer is present, so need to clean up ImagePullSecret reference
 		if serviceAccount == nil {
@@ -181,7 +203,7 @@ func (r *genericReconciler[O]) cleanUp(acrBinding O,
 		} else {
 			updated := serviceAccount.DeepCopy()
 			updated.ImagePullSecrets = slices.DeleteFunc(updated.ImagePullSecrets, func(reference corev1.LocalObjectReference) bool {
-				return reference.Name == pullSecretName(acrBinding.GetName())
+				return reference.Name == r.GetPullSecretName(acrBinding)
 			})
 			if len(updated.ImagePullSecrets) != len(serviceAccount.ImagePullSecrets) {
 				log.WithValues("serviceAccount", crclient.ObjectKeyFromObject(serviceAccount).String()).Info("updating service account to remove image pull secret")
@@ -189,10 +211,11 @@ func (r *genericReconciler[O]) cleanUp(acrBinding O,
 			}
 		}
 
-		// remove the secret
-		if pullSecret != nil {
-			log.WithValues("secret", crclient.ObjectKeyFromObject(pullSecret).String()).Info("cleaning up pull credential")
-			return &action[O]{deleteSecret: pullSecret}
+		// remove the secrets
+		for _, pullSecret := range pullSecrets {
+			deleted := pullSecret.DeepCopy()
+			log.WithValues("secret", crclient.ObjectKeyFromObject(deleted).String()).Info("cleaning up pull credential")
+			return &action[O]{deleteSecret: deleted}
 		}
 
 		// remove our finalizer from the list and update it.

--- a/internal/controller/legacy_token_cleanup_controller.go
+++ b/internal/controller/legacy_token_cleanup_controller.go
@@ -1,0 +1,208 @@
+package controller
+
+import (
+	"context"
+	"os"
+	"slices"
+
+	"github.com/go-logr/logr"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	msiacrpullv1beta1 "github.com/Azure/msi-acrpull/api/v1beta1"
+)
+
+const (
+	serviceAccountField   = ".spec.serviceAccountName"
+	imagePullSecretsField = ".imagePullSecrets"
+)
+
+func indexPullBindingByServiceAccount(object client.Object) []string {
+	acrPullBinding, ok := object.(*msiacrpullv1beta1.AcrPullBinding)
+	if !ok {
+		return nil
+	}
+
+	return []string{getServiceAccountName(acrPullBinding.Spec.ServiceAccountName)}
+}
+
+func enqueuePullBindingsForServiceAccount(mgr ctrl.Manager) func(ctx context.Context, object client.Object) []reconcile.Request {
+	return func(ctx context.Context, object client.Object) []reconcile.Request {
+		var pullBindings msiacrpullv1beta1.AcrPullBindingList
+		if err := mgr.GetClient().List(ctx, &pullBindings, client.InNamespace(object.GetNamespace()), client.MatchingFields{serviceAccountField: object.GetName()}); err != nil {
+			return nil
+		}
+		var requests []reconcile.Request
+		for _, pullBinding := range pullBindings.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(&pullBinding),
+			})
+		}
+		return requests
+	}
+}
+
+type LegacyTokenCleanupController struct {
+	Client client.Client
+	Log    logr.Logger
+}
+
+func (c *LegacyTokenCleanupController) SetupWithManager(_ context.Context, mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("legacy-token-cleanup").
+		For(&msiacrpullv1beta1.AcrPullBinding{}).
+		// n.b. the other controller always runs and sets up the indexer, so we can just use it
+		Watches(&corev1.ServiceAccount{}, handler.EnqueueRequestsFromMapFunc(enqueuePullBindingsForServiceAccount(mgr))).
+		Complete(c)
+}
+
+// Reconcile cleans up legacy ACR pull token secrets and references to them from the cluster if new tokens have
+// been generated.
+func (c *LegacyTokenCleanupController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := c.Log.WithValues("acrpullbinding", req.NamespacedName)
+
+	acrBinding := &msiacrpullv1beta1.AcrPullBinding{}
+	if err := c.Client.Get(ctx, req.NamespacedName, acrBinding); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "unable to fetch acrPullBinding.")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	serviceAccountName := getServiceAccountName(acrBinding.Spec.ServiceAccountName)
+	serviceAccount := &corev1.ServiceAccount{}
+	if err := c.Client.Get(ctx, types.NamespacedName{
+		Namespace: req.Namespace,
+		Name:      serviceAccountName,
+	}, serviceAccount); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to get service account")
+			return ctrl.Result{}, err
+		}
+	}
+
+	legacySecret := &corev1.Secret{}
+	if err := c.Client.Get(ctx, types.NamespacedName{
+		Namespace: req.Namespace,
+		Name:      legacySecretName(acrBinding.ObjectMeta.Name),
+	}, legacySecret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to get legacy secret")
+			return ctrl.Result{}, err
+		} else {
+			legacySecret = nil
+		}
+	}
+	action := c.reconcile(acrBinding, serviceAccount, legacySecret)
+
+	return c.execute(ctx, action)
+}
+
+func (c *LegacyTokenCleanupController) reconcile(acrBinding *msiacrpullv1beta1.AcrPullBinding, serviceAccount *corev1.ServiceAccount, legacySecret *corev1.Secret) *cleanupAction {
+	if !slices.ContainsFunc(serviceAccount.ImagePullSecrets, func(reference corev1.LocalObjectReference) bool {
+		return reference.Name == pullSecretName(acrBinding.ObjectMeta.Name)
+	}) {
+		// this service account doesn't have a non-legacy pull token generated yet, so we shouldn't remove anything
+		return nil
+	}
+
+	if slices.ContainsFunc(serviceAccount.ImagePullSecrets, func(reference corev1.LocalObjectReference) bool {
+		return reference.Name == legacySecretName(acrBinding.ObjectMeta.Name)
+	}) {
+		// this service account still refers to the legacy token, we need to clean that up
+		updated := serviceAccount.DeepCopy()
+		updated.ImagePullSecrets = slices.DeleteFunc(updated.ImagePullSecrets, func(reference corev1.LocalObjectReference) bool {
+			return reference.Name == legacySecretName(acrBinding.ObjectMeta.Name)
+		})
+		c.Log.WithValues("serviceAccountNamespace", updated.Namespace, "serviceAccountName", updated.Name).Info("removing reference to legacy pull token secret from service account")
+		return &cleanupAction{updateServiceAccount: updated}
+	}
+
+	if legacySecret == nil {
+		// legacy secret already gone, so there's nothing left to do for this pull binding. In this case, it is
+		// possible that every object that required cleanup is already gone; in which case we should exit the
+		// process, so the Pod that succeeds us can filter the informers used to drive the controller and stop
+		// having to track extraneous objects
+		c.Log.Info("checking to see if legacy token cleanup is complete")
+		return &cleanupAction{checkCompletion: true}
+	}
+
+	// legacy secret still exists, let's clean it up
+	c.Log.WithValues("tokenNamespace", legacySecret.Namespace, "tokenName", legacySecret.Name).Info("cleaning up legacy pull token secret")
+	return &cleanupAction{deleteSecret: legacySecret}
+}
+
+func (c *LegacyTokenCleanupController) execute(ctx context.Context, action *cleanupAction) (ctrl.Result, error) {
+	if action == nil {
+		return ctrl.Result{}, nil
+	}
+	action.validate()
+	if action.updateServiceAccount != nil {
+		return ctrl.Result{}, c.Client.Update(ctx, action.updateServiceAccount)
+	} else if action.deleteSecret != nil {
+		return ctrl.Result{}, c.Client.Delete(ctx, action.deleteSecret)
+	} else if action.checkCompletion {
+		return ctrl.Result{}, c.checkCompletion(ctx)
+	}
+	return ctrl.Result{}, nil
+}
+
+type cleanupAction struct {
+	updateServiceAccount *corev1.ServiceAccount
+	deleteSecret         *corev1.Secret
+	checkCompletion      bool
+}
+
+func (a *cleanupAction) validate() {
+	var present int
+	if a.updateServiceAccount != nil {
+		present++
+	}
+	if a.deleteSecret != nil {
+		present++
+	}
+	if a.checkCompletion {
+		present++
+	}
+	if present > 1 {
+		panic("programmer error: more than one action specified in reconciliation loop")
+	}
+}
+
+func (c *LegacyTokenCleanupController) checkCompletion(ctx context.Context) error {
+	var pullBindings msiacrpullv1beta1.AcrPullBindingList
+	if err := c.Client.List(ctx, &pullBindings); err != nil {
+		return err
+	}
+
+	var secrets corev1.SecretList
+	if err := c.Client.List(ctx, &secrets); err != nil {
+		return err
+	}
+
+	if !LegacyPullSecretsPresent(pullBindings, secrets) {
+		c.Log.Info("no more legacy pull secrets present, restarting...")
+		os.Exit(0)
+	}
+	return nil
+}
+
+// LegacyPullSecretsPresent determines if any legacy pull secrets still exist on the cluster.
+func LegacyPullSecretsPresent(pullBindings msiacrpullv1beta1.AcrPullBindingList, secrets corev1.SecretList) bool {
+	for _, pullBinding := range pullBindings.Items {
+		if slices.ContainsFunc(secrets.Items, func(secret corev1.Secret) bool {
+			return secret.Name == legacySecretName(pullBinding.ObjectMeta.Name)
+		}) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/legacy_token_cleanup_controller_test.go
+++ b/internal/controller/legacy_token_cleanup_controller_test.go
@@ -1,0 +1,86 @@
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/google/go-cmp/cmp"
+
+	msiacrpullv1beta1 "github.com/Azure/msi-acrpull/api/v1beta1"
+)
+
+func Test_LegacyTokenCleanupController_reconcile(t *testing.T) {
+	for _, testCase := range []struct {
+		name           string
+		acrBinding     *msiacrpullv1beta1.AcrPullBinding
+		serviceAccount *corev1.ServiceAccount
+		legacySecret   *corev1.Secret
+
+		action *cleanupAction
+	}{
+		{
+			name:       "legacy secret exists, but no new secret generated, do nothing",
+			acrBinding: &msiacrpullv1beta1.AcrPullBinding{ObjectMeta: metav1.ObjectMeta{Name: "binding"}},
+			serviceAccount: &corev1.ServiceAccount{
+				ObjectMeta:       metav1.ObjectMeta{Name: "default"},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "binding-msi-acrpull-secret"}},
+			},
+			legacySecret: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "binding-msi-acrpull-secret"}},
+		},
+		{
+			name:       "legacy secret exists, new secret generated, clean up service account",
+			acrBinding: &msiacrpullv1beta1.AcrPullBinding{ObjectMeta: metav1.ObjectMeta{Name: "binding"}},
+			serviceAccount: &corev1.ServiceAccount{
+				ObjectMeta:       metav1.ObjectMeta{Name: "default"},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "binding-msi-acrpull-secret"}, {Name: "acr-pull-binding-37d7ayn69u"}},
+			},
+			legacySecret: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "binding-msi-acrpull-secret"}},
+			action: &cleanupAction{
+				updateServiceAccount: &corev1.ServiceAccount{
+					ObjectMeta:       metav1.ObjectMeta{Name: "default"},
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+				},
+			},
+		},
+		{
+			name:       "legacy secret exists, new secret generated, service account cleaned up, delete secret",
+			acrBinding: &msiacrpullv1beta1.AcrPullBinding{ObjectMeta: metav1.ObjectMeta{Name: "binding"}},
+			serviceAccount: &corev1.ServiceAccount{
+				ObjectMeta:       metav1.ObjectMeta{Name: "default"},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+			},
+			legacySecret: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "binding-msi-acrpull-secret"}},
+			action: &cleanupAction{
+				deleteSecret: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "binding-msi-acrpull-secret"}},
+			},
+		},
+		{
+			name:       "legacy secret gone, new secret generated, clean up service account",
+			acrBinding: &msiacrpullv1beta1.AcrPullBinding{ObjectMeta: metav1.ObjectMeta{Name: "binding"}},
+			serviceAccount: &corev1.ServiceAccount{
+				ObjectMeta:       metav1.ObjectMeta{Name: "default"},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "binding-msi-acrpull-secret"}, {Name: "acr-pull-binding-37d7ayn69u"}},
+			},
+			action: &cleanupAction{
+				updateServiceAccount: &corev1.ServiceAccount{
+					ObjectMeta:       metav1.ObjectMeta{Name: "default"},
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding-37d7ayn69u"}},
+				},
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			controller := LegacyTokenCleanupController{
+				Client: nil,
+				Log:    ctrl.Log.WithName("test"),
+			}
+			got := controller.reconcile(testCase.acrBinding, testCase.serviceAccount, testCase.legacySecret)
+			if diff := cmp.Diff(testCase.action, got, cmp.AllowUnexported(cleanupAction{})); diff != "" {
+				t.Errorf("-want, +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -61,18 +61,20 @@ _output/image.json: _output/infrastructure.json
 _output/image: _output/image.json
 	echo "$(shell jq --raw-output '.properties.outputs.acr.value.serviceRegistryName.value' < _output/infrastructure.json ).azurecr.io/msi-acrpull@$(shell jq --raw-output '.digest' _output/image.json )" > _output/image
 
-# this is a nasty hack, ideally we'd have some centrally-available ACR to pull old images from
-PREVIOUS_TAG=$(shell git describe --tags --abbrev=0)
-_output/previous-repo:
+_output/legacy.yaml: $(KUSTOMIZE)
 	git clone https://github.com/Azure/msi-acrpull.git _output/previous-repo
+	cd _output/previous-repo && git checkout v0.1.3
+	rm -rf _output/config
+	cp -r _output/previous-repo/config _output/config
+	cd _output/config/manager && $(KUSTOMIZE) edit set image controller="mcr.microsoft.com/aks/msi-acrpull:v0.1.3" && cd -
+	$(KUSTOMIZE) build _output/config/default > $@
+
+PREVIOUS_TAG=$(shell git describe --tags --abbrev=0)
+_output/previous-chart.yaml: _output/legacy.yaml
 	cd _output/previous-repo && git checkout "$(PREVIOUS_TAG)"
-
-_output/previous-image.json: _output/infrastructure.json _output/previous-repo
-	az acr build --registry "$(shell jq --raw-output '.properties.outputs.acr.value.serviceRegistryName.value' < _output/infrastructure.json )" --image "msi-acrpull:$(PREVIOUS_TAG)" _output/previous-repo
-	az acr repository show --name "$(shell jq --raw-output '.properties.outputs.acr.value.serviceRegistryName.value' < _output/infrastructure.json )" --image "msi-acrpull:$(PREVIOUS_TAG)" --output json > _output/previous-image.json
-
-_output/previous-image: _output/previous-image.json
-	echo "$(shell jq --raw-output '.properties.outputs.acr.value.serviceRegistryName.value' < _output/infrastructure.json ).azurecr.io/msi-acrpull@$(shell jq --raw-output '.digest' _output/previous-image.json )" > _output/previous-image
+	cp values.template.yaml _output/previous-values.yaml
+	sed -i -e 's|IMAGE_DIGEST|mcr.microsoft.com/aks/msi-acrpull:$(PREVIOUS_TAG)|' -e 's|NAMESPACE|acrpull-previous|' _output/previous-values.yaml
+	$(HELM) template --kubeconfig _output/aks.kubeconfig acrpull ./../config/helm --values _output/previous-values.yaml --create-namespace --dry-run=server > $@
 
 prometheus-crds: _output/assets/0alertmanagerConfigCustomResourceDefinition.yaml _output/assets/0prometheusCustomResourceDefinition.yaml _output/assets/0servicemonitorCustomResourceDefinition.yaml _output/assets/0alertmanagerCustomResourceDefinition.yaml _output/assets/0prometheusagentCustomResourceDefinition.yaml _output/assets/0thanosrulerCustomResourceDefinition.yaml _output/assets/0podmonitorCustomResourceDefinition.yaml _output/assets/0prometheusruleCustomResourceDefinition.yaml _output/assets/namespace.yaml _output/assets/0probeCustomResourceDefinition.yaml _output/assets/0scrapeconfigCustomResourceDefinition.yaml
 
@@ -91,14 +93,10 @@ _output/config:
 	rm -rf _output/config
 	cp -r ./../config _output/config
 
-_output/deploy/new-image: _output/deploy/previous _output/deploy/image
-	touch $@
-
 _output/deploy/image: _output/image
-_output/deploy/previous-image: _output/previous-image
-_output/deploy/image _output/deploy/previous-image: _output/aks.kubeconfig $(HELM) _output/deploy/prometheus-crds _output/system-vmss-puller.json
+_output/deploy/image: _output/aks.kubeconfig $(HELM) _output/deploy/prometheus-crds _output/system-vmss-puller.json
 	cp values.template.yaml _output/values.yaml
-	sed -i -e 's|IMAGE_DIGEST|$(shell cat _output/$(notdir $@) )|' _output/values.yaml
+	sed -i -e 's|IMAGE_DIGEST|$(shell cat _output/$(notdir $@) )|' -e 's|NAMESPACE|acrpull|' _output/values.yaml
 	$(HELM) template --kubeconfig _output/aks.kubeconfig acrpull ./../config/helm --values _output/values.yaml --create-namespace --dry-run=server > _output/chart.yaml
 	kubectl --kubeconfig _output/aks.kubeconfig apply --server-side -f _output/chart.yaml
 	kubectl --kubeconfig _output/aks.kubeconfig wait --for condition=Established crd/acrpullbindings.msi-acrpull.microsoft.com
@@ -108,14 +106,14 @@ _output/deploy/image _output/deploy/previous-image: _output/aks.kubeconfig $(HEL
 
 deploy:
 	cp values.template.yaml _output/values.yaml
-	sed -i -e 's|IMAGE_DIGEST|$(shell cat _output/image )|' _output/values.yaml
+	sed -i -e 's|IMAGE_DIGEST|$(shell cat _output/image )|' -e 's|NAMESPACE|acrpull|' _output/values.yaml
 	$(HELM) template --kubeconfig _output/aks.kubeconfig acrpull ./../config/helm --values _output/values.yaml --create-namespace --dry-run=server > _output/chart.yaml
 	kubectl --kubeconfig _output/aks.kubeconfig apply --server-side -f _output/chart.yaml
 	kubectl --kubeconfig _output/aks.kubeconfig wait --for condition=Established crd/acrpullbindings.msi-acrpull.microsoft.com
 	kubectl --kubeconfig _output/aks.kubeconfig wait --for condition=Established crd/acrpullbindings.acrpull.microsoft.com
 	kubectl --kubeconfig _output/aks.kubeconfig --namespace acrpull wait --for condition=Available deployment/acrpull --timeout 120s
 
-_output/deploy/previous: _output/deploy/previous-image _output/system-vmss-puller.json
+_output/deploy/previous: _output/system-vmss-puller.json
 	cp pullbinding.template.yaml _output/pullbinding.yaml
 	sed -i -e 's|MANAGED_IDENTITY_RESOURCE_ID|$(shell jq --raw-output '.properties.outputs.acr.value.pullerIdentity.value' < _output/infrastructure.json )|g' -e 's|ACR_SERVER|$(shell jq --raw-output '.properties.outputs.acr.value.registryName.value' < _output/infrastructure.json).azurecr.io|g' _output/pullbinding.yaml
 	kubectl --kubeconfig _output/aks.kubeconfig apply --server-side -f _output/pullbinding.yaml
@@ -123,7 +121,7 @@ _output/deploy/previous: _output/deploy/previous-image _output/system-vmss-pulle
 	touch $@
 
 .PHONY: test
-test: _output/deploy/new-image _output/alice _output/bob _output/tenant
+test: _output/deploy/image _output/alice _output/bob _output/tenant
 	$(MAKE) test-e2e
 
 .PHONY: test-e2e

--- a/test/Makefile
+++ b/test/Makefile
@@ -61,6 +61,19 @@ _output/image.json: _output/infrastructure.json
 _output/image: _output/image.json
 	echo "$(shell jq --raw-output '.properties.outputs.acr.value.serviceRegistryName.value' < _output/infrastructure.json ).azurecr.io/msi-acrpull@$(shell jq --raw-output '.digest' _output/image.json )" > _output/image
 
+# this is a nasty hack, ideally we'd have some centrally-available ACR to pull old images from
+PREVIOUS_TAG=$(shell git describe --tags --abbrev=0)
+_output/previous-repo:
+	git clone https://github.com/Azure/msi-acrpull.git _output/previous-repo
+	cd _output/previous-repo && git checkout "$(PREVIOUS_TAG)"
+
+_output/previous-image.json: _output/infrastructure.json _output/previous-repo
+	az acr build --registry "$(shell jq --raw-output '.properties.outputs.acr.value.serviceRegistryName.value' < _output/infrastructure.json )" --image "msi-acrpull:$(PREVIOUS_TAG)" _output/previous-repo
+	az acr repository show --name "$(shell jq --raw-output '.properties.outputs.acr.value.serviceRegistryName.value' < _output/infrastructure.json )" --image "msi-acrpull:$(PREVIOUS_TAG)" --output json > _output/previous-image.json
+
+_output/previous-image: _output/previous-image.json
+	echo "$(shell jq --raw-output '.properties.outputs.acr.value.serviceRegistryName.value' < _output/infrastructure.json ).azurecr.io/msi-acrpull@$(shell jq --raw-output '.digest' _output/previous-image.json )" > _output/previous-image
+
 prometheus-crds: _output/assets/0alertmanagerConfigCustomResourceDefinition.yaml _output/assets/0prometheusCustomResourceDefinition.yaml _output/assets/0servicemonitorCustomResourceDefinition.yaml _output/assets/0alertmanagerCustomResourceDefinition.yaml _output/assets/0prometheusagentCustomResourceDefinition.yaml _output/assets/0thanosrulerCustomResourceDefinition.yaml _output/assets/0podmonitorCustomResourceDefinition.yaml _output/assets/0prometheusruleCustomResourceDefinition.yaml _output/assets/namespace.yaml _output/assets/0probeCustomResourceDefinition.yaml _output/assets/0scrapeconfigCustomResourceDefinition.yaml
 
 _output/assets/0alertmanagerConfigCustomResourceDefinition.yaml _output/assets/0prometheusCustomResourceDefinition.yaml _output/assets/0servicemonitorCustomResourceDefinition.yaml _output/assets/0alertmanagerCustomResourceDefinition.yaml _output/assets/0prometheusagentCustomResourceDefinition.yaml _output/assets/0thanosrulerCustomResourceDefinition.yaml _output/assets/0podmonitorCustomResourceDefinition.yaml _output/assets/0prometheusruleCustomResourceDefinition.yaml _output/assets/namespace.yaml _output/assets/0probeCustomResourceDefinition.yaml _output/assets/0scrapeconfigCustomResourceDefinition.yaml:
@@ -78,11 +91,12 @@ _output/config:
 	rm -rf _output/config
 	cp -r ./../config _output/config
 
-_output/deploy/new-image: _output/deploy/image
+_output/deploy/new-image: _output/deploy/previous _output/deploy/image
 	touch $@
 
 _output/deploy/image: _output/image
-_output/deploy/image: _output/aks.kubeconfig $(HELM) _output/deploy/prometheus-crds _output/system-vmss-puller.json
+_output/deploy/previous-image: _output/previous-image
+_output/deploy/image _output/deploy/previous-image: _output/aks.kubeconfig $(HELM) _output/deploy/prometheus-crds _output/system-vmss-puller.json
 	cp values.template.yaml _output/values.yaml
 	sed -i -e 's|IMAGE_DIGEST|$(shell cat _output/$(notdir $@) )|' _output/values.yaml
 	$(HELM) template --kubeconfig _output/aks.kubeconfig acrpull ./../config/helm --values _output/values.yaml --create-namespace --dry-run=server > _output/chart.yaml
@@ -100,6 +114,13 @@ deploy:
 	kubectl --kubeconfig _output/aks.kubeconfig wait --for condition=Established crd/acrpullbindings.msi-acrpull.microsoft.com
 	kubectl --kubeconfig _output/aks.kubeconfig wait --for condition=Established crd/acrpullbindings.acrpull.microsoft.com
 	kubectl --kubeconfig _output/aks.kubeconfig --namespace acrpull wait --for condition=Available deployment/acrpull --timeout 120s
+
+_output/deploy/previous: _output/deploy/previous-image _output/system-vmss-puller.json
+	cp pullbinding.template.yaml _output/pullbinding.yaml
+	sed -i -e 's|MANAGED_IDENTITY_RESOURCE_ID|$(shell jq --raw-output '.properties.outputs.acr.value.pullerIdentity.value' < _output/infrastructure.json )|g' -e 's|ACR_SERVER|$(shell jq --raw-output '.properties.outputs.acr.value.registryName.value' < _output/infrastructure.json).azurecr.io|g' _output/pullbinding.yaml
+	kubectl --kubeconfig _output/aks.kubeconfig apply --server-side -f _output/pullbinding.yaml
+	kubectl --kubeconfig _output/aks.kubeconfig wait --for 'jsonpath={.imagePullSecrets[0]}' --namespace default serviceaccount/default
+	touch $@
 
 .PHONY: test
 test: _output/deploy/new-image _output/alice _output/bob _output/tenant

--- a/test/e2e_v1beta2_test.go
+++ b/test/e2e_v1beta2_test.go
@@ -328,6 +328,7 @@ func TestValidatingAdmissionPolicies(t *testing.T) {
 
 		t.Run("can't adopt existing secrets", func(t *testing.T) {
 			t.Parallel()
+			t.Skip("skipping until we turn this back on")
 
 			const name = "existing"
 			existing, createErr := kubeClient.CoreV1().Secrets(namespace).Create(ctx, &corev1.Secret{

--- a/test/pullbinding.template.yaml
+++ b/test/pullbinding.template.yaml
@@ -1,0 +1,8 @@
+apiVersion: msi-acrpull.microsoft.com/v1beta1
+kind: AcrPullBinding
+metadata:
+  name: previous-pull-binding
+  namespace: default
+spec:
+  managedIdentityResourceID: "MANAGED_IDENTITY_RESOURCE_ID"
+  acrServer: "ACR_SERVER"

--- a/test/values.template.yaml
+++ b/test/values.template.yaml
@@ -1,4 +1,6 @@
+namespace: NAMESPACE
 image: IMAGE_DIGEST
+replicas: 1
 ttlRotationFraction: 0.01
 affinity:
   nodeAffinity:


### PR DESCRIPTION
Revert "*: remove legacy token cleanup controller"

This reverts commit f202b1a281c34ae05fee6c3b7efb8db09e330aae.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

.github: use ubuntu-latest

Ubuntu 20.04 is EOL, there's no need to explicitly use it.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

internal/controller: label legacy secrets instead of cleanup

In order to make the name of the pull secret created by this controller
known a prioi, and to paper over the backwards-incompatibility necessary
to support arbitrary length binding names, we need to keep the previous
legacy names unchanged. When the controller starts, labels will need to
be added to previous secrets so we can filter our informers in the
future.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

config/helm: allow configuring replicas

In test, there's no need to have multiple replicas. Redeployment will
still run leader election, so we continue to test that function, and
getting logs is trivial.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

test/eventually: expose condition of pull bindings

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

internal/controller: simplify naming scheme

Pull secrets created by these controllers will no longer contain hashes
of the binding name in the secret name unless strictly necessary to
abide by secret naming rules.

The controllers now list secrets associated with a binding and manage
the list, removing unnecessary secrets. This is required to correctly
handle the upgrade from previous versions of the controller.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

