### PR TITLE
*: clean up references to old secrets before removing them

### DIFF
--- a/internal/controller/acrpullbinding_controller_test.go
+++ b/internal/controller/acrpullbinding_controller_test.go
@@ -818,6 +818,66 @@ func Test_ACRPullBindingController_reconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "user changes bound service account during extraneous pull secret cleanup, remove all previous references",
+			acrBinding: &msiacrpullv1beta1.AcrPullBinding{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},
+				Spec:       msiacrpullv1beta1.AcrPullBindingSpec{},
+				Status: msiacrpullv1beta1.AcrPullBindingStatus{
+					LastTokenRefreshTime: &metav1.Time{Time: fakeClock.Now()},
+					TokenExpirationTime:  &metav1.Time{Time: longExpiry},
+				},
+			},
+			serviceAccount: &corev1.ServiceAccount{
+				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "default"},
+				ImagePullSecrets: []corev1.LocalObjectReference{},
+			},
+			referencingServiceAccounts: []corev1.ServiceAccount{
+				{
+					ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "binding-msi-acrpull-secret"},{Name: "previous-binding-msi-acrpull-secret"},{Name: "extraneous"}},
+				},
+			},
+			pullSecrets: []corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "binding-msi-acrpull-secret",
+					Labels: map[string]string{
+						"acr.microsoft.com/binding": "binding",
+					},
+					Annotations: map[string]string{
+						"acr.microsoft.com/token.expiry":  longExpiry.Format(time.RFC3339),
+						"acr.microsoft.com/token.refresh": fakeClock.Now().Format(time.RFC3339),
+						"acr.microsoft.com/token.inputs":  "2wucoufm4eqegr6z5nmg00bvmwguubf86kfxk6yir9pw",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "msi-acrpull.microsoft.com/v1beta1",
+							Kind:               "AcrPullBinding",
+							Name:               "binding",
+							Controller:         ptr.To(true),
+							BlockOwnerDeletion: ptr.To(true),
+						},
+					},
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{"auths":{"DefaultACRServer":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "previous-binding-msi-acrpull-secret",
+					Labels: map[string]string{
+						"acr.microsoft.com/binding": "binding",
+					},
+				},
+			}},
+			output: &action[*msiacrpullv1beta1.AcrPullBinding]{
+				updateServiceAccount: &corev1.ServiceAccount{
+					ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "extraneous"}},
+				},
+			},
+		},
+		{
 			name: "user changes ACR server, regenerate",
 			acrBinding: &msiacrpullv1beta1.AcrPullBinding{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},

--- a/internal/controller/acrpullbinding_v1beta2_controller_test.go
+++ b/internal/controller/acrpullbinding_v1beta2_controller_test.go
@@ -735,6 +735,78 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "everything up-to-date, remove extraneous pull secret reference from service account",
+			acrBinding: &msiacrpullv1beta2.AcrPullBinding{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},
+				Spec: msiacrpullv1beta2.AcrPullBindingSpec{
+					ServiceAccountName: "delegate",
+					ACR: msiacrpullv1beta2.AcrConfiguration{
+						Server:      "registry.azurecr.io",
+						Scope:       "repository:testing:pull,push",
+						Environment: msiacrpullv1beta2.AzureEnvironmentPublicCloud,
+					},
+					Auth: msiacrpullv1beta2.AuthenticationMethod{
+						ManagedIdentity: &msiacrpullv1beta2.ManagedIdentityAuth{
+							ClientID: "client-id",
+						},
+					},
+				},
+				Status: msiacrpullv1beta2.AcrPullBindingStatus{
+					LastTokenRefreshTime: &metav1.Time{Time: fakeClock.Now()},
+					TokenExpirationTime:  &metav1.Time{Time: longExpiry},
+				},
+			},
+			serviceAccount: &corev1.ServiceAccount{
+				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}, {Name: "acr-pull-binding-other"}},
+			},
+			referencingServiceAccounts: []corev1.ServiceAccount{
+				{
+					ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}, {Name: "acr-pull-binding-other"}},
+				},
+			},
+			pullSecrets: []corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "acr-pull-binding",
+					Labels: map[string]string{
+						"acr.microsoft.com/binding": "binding",
+					},
+					Annotations: map[string]string{
+						"acr.microsoft.com/token.expiry":  longExpiry.Format(time.RFC3339),
+						"acr.microsoft.com/token.refresh": fakeClock.Now().Format(time.RFC3339),
+						"acr.microsoft.com/token.inputs":  "bznn8knczhrdktghbm88h4ock013v94i8e8cslwlrob",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "acrpull.microsoft.com/v1beta2",
+							Kind:               "AcrPullBinding",
+							Name:               "binding",
+							Controller:         ptr.To(true),
+							BlockOwnerDeletion: ptr.To(true),
+						},
+					},
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{"auths":{"registry.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "acr-pull-binding-other",
+					Labels: map[string]string{
+						"acr.microsoft.com/binding": "binding",
+					},
+				},
+			}},
+			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
+				updateServiceAccount: &corev1.ServiceAccount{
+					ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}},
+				},
+			},
+		},
+		{
 			name: "everything up-to-date, remove extraneous pull secret",
 			acrBinding: &msiacrpullv1beta2.AcrPullBinding{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},

--- a/internal/controller/acrpullbinding_v1beta2_controller_test.go
+++ b/internal/controller/acrpullbinding_v1beta2_controller_test.go
@@ -1017,6 +1017,66 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "user changes bound service account during extraneous pull secret cleanup, remove all previous references",
+			acrBinding: &msiacrpullv1beta2.AcrPullBinding{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},
+				Spec:       msiacrpullv1beta2.AcrPullBindingSpec{},
+				Status: msiacrpullv1beta2.AcrPullBindingStatus{
+					LastTokenRefreshTime: &metav1.Time{Time: fakeClock.Now()},
+					TokenExpirationTime:  &metav1.Time{Time: longExpiry},
+				},
+			},
+			serviceAccount: &corev1.ServiceAccount{
+				ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "default"},
+				ImagePullSecrets: []corev1.LocalObjectReference{},
+			},
+			referencingServiceAccounts: []corev1.ServiceAccount{
+				{
+					ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "acr-pull-binding"}, {Name: "acr-pull-binding-previous"}, {Name: "extraneous"}},
+				},
+			},
+			pullSecrets: []corev1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "acr-pull-binding",
+					Labels: map[string]string{
+						"acr.microsoft.com/binding": "binding",
+					},
+					Annotations: map[string]string{
+						"acr.microsoft.com/token.expiry":  longExpiry.Format(time.RFC3339),
+						"acr.microsoft.com/token.refresh": fakeClock.Now().Format(time.RFC3339),
+						"acr.microsoft.com/token.inputs":  "bznn8knczhrdktghbm88h4ock013v94i8e8cslwlrob",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "acrpull.microsoft.com/v1beta2",
+							Kind:               "AcrPullBinding",
+							Name:               "binding",
+							Controller:         ptr.To(true),
+							BlockOwnerDeletion: ptr.To(true),
+						},
+					},
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{"auths":{"registry.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0LmF6dXJlY3IuaW8iLCJleHAiOjExMzYzMDA2NDUsImdyYW50X3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxMTM2MDQxNDQ1LCJpc3MiOiJBenVyZSBDb250YWluZXIgUmVnaXN0cnkiLCJqdGkiOiJiYjhkNmQzZC1jN2IwLTRmOTYtYTM5MC04NzM4ZjczMGU4YzYiLCJuYmYiOjExMzYxMjc4NDUsInBlcm1pc3Npb25zIjp7ImFjdGlvbnMiOlsicmVhZCJdfSwidmVyc2lvbiI6MX0.lb8wJOjWSmpVBX-qf0VTjRTKcSiPsqDAe_g-Fow_3LHcqXUyfRspjmFmH9YtaFN3TsA72givXOBE_UQSj2i1CPshvXVfpGuJRPssy_olq1uzfr2L8w6AL1jwM96gCP3e2Od5YT8p6Dbg4RDoBy5xz1zHluoUH2-4jiCh81bRzyAjQGZmKf1MQygLVHHuCjLlijpdw2wHp5nB4m27Yi5z5rrgLzcvXQnSEGIj2t0BY_AuNRbffEFCCFHeDlu6ud1F-Ak35ljIWhkJumP3Zud-rPdIc1YeCQCSGT2-yk4epVX_N4UPsk3hc6XeZxC4ctu9UX9mqfSNe5ZZlO6dtt963A","email":"msi-acrpull@azurecr.io","auth":"MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmV5SmhiR2NpT2lKRlV6STFOaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoZFdRaU9pSjBaWE4wTG1GNmRYSmxZM0l1YVc4aUxDSmxlSEFpT2pFeE16WXpNREEyTkRVc0ltZHlZVzUwWDNSNWNHVWlPaUp5WldaeVpYTm9YM1J2YTJWdUlpd2lhV0YwSWpveE1UTTJNRFF4TkRRMUxDSnBjM01pT2lKQmVuVnlaU0JEYjI1MFlXbHVaWElnVW1WbmFYTjBjbmtpTENKcWRHa2lPaUppWWpoa05tUXpaQzFqTjJJd0xUUm1PVFl0WVRNNU1DMDROek00Wmpjek1HVTRZellpTENKdVltWWlPakV4TXpZeE1qYzRORFVzSW5CbGNtMXBjM05wYjI1eklqcDdJbUZqZEdsdmJuTWlPbHNpY21WaFpDSmRmU3dpZG1WeWMybHZiaUk2TVgwLmxiOHdKT2pXU21wVkJYLXFmMFZUalJUS2NTaVBzcURBZV9nLUZvd18zTEhjcVhVeWZSc3BqbUZtSDlZdGFGTjNUc0E3MmdpdlhPQkVfVVFTajJpMUNQc2h2WFZmcEd1SlJQc3N5X29scTF1emZyMkw4dzZBTDFqd005NmdDUDNlMk9kNVlUOHA2RGJnNFJEb0J5NXh6MXpIbHVvVUgyLTRqaUNoODFiUnp5QWpRR1ptS2YxTVF5Z0xWSEh1Q2pMbGlqcGR3MndIcDVuQjRtMjdZaTV6NXJyZ0x6Y3ZYUW5TRUdJajJ0MEJZX0F1TlJiZmZFRkNDRkhlRGx1NnVkMUYtQWszNWxqSVdoa0p1bVAzWnVkLXJQZEljMVllQ1FDU0dUMi15azRlcFZYX040VVBzazNoYzZYZVp4QzRjdHU5VVg5bXFmU05lNVpabE82ZHR0OTYzQQ=="}}}`),
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns", Name: "acr-pull-binding-previous",
+					Labels: map[string]string{
+						"acr.microsoft.com/binding": "binding",
+					},
+				},
+			}},
+			output: &action[*msiacrpullv1beta2.AcrPullBinding]{
+				updateServiceAccount: &corev1.ServiceAccount{
+					ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "extraneous"}},
+				},
+			},
+		},
+		{
 			name: "user changes ACR server, regenerate",
 			acrBinding: &msiacrpullv1beta2.AcrPullBinding{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding", Finalizers: []string{"msi-acrpull.microsoft.com"}},


### PR DESCRIPTION
If the controller notices that extraneous secrets exist that need to be cleaned up, it first needs to remove references to those secrets from the service account. This only happens once the new secret exists and is referenced, so there should be no discontinuity in pull credentials.