### PR TITLE
feat: use ACR Audience Entra token for AuthN

### DIFF
--- a/internal/controller/acrpullbinding_controller_test.go
+++ b/internal/controller/acrpullbinding_controller_test.go
@@ -834,7 +834,7 @@ func Test_ACRPullBindingController_reconcile(t *testing.T) {
 			referencingServiceAccounts: []corev1.ServiceAccount{
 				{
 					ObjectMeta:       metav1.ObjectMeta{Namespace: "ns", Name: "delegate"},
-					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "binding-msi-acrpull-secret"},{Name: "previous-binding-msi-acrpull-secret"},{Name: "extraneous"}},
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "binding-msi-acrpull-secret"}, {Name: "previous-binding-msi-acrpull-secret"}, {Name: "extraneous"}},
 				},
 			},
 			pullSecrets: []corev1.Secret{{

--- a/pkg/authorizer/authorizer.go
+++ b/pkg/authorizer/authorizer.go
@@ -26,10 +26,10 @@ func (az *Authorizer) AcquireACRAccessToken(ctx context.Context, identityResourc
 	} else {
 		return azcore.AccessToken{}, fmt.Errorf("either a client ID or a resource ID is required")
 	}
-	armToken, err := AcquireARMToken(ctx, id)
+	acrAudienceEntraToken, err := AcquireACRAudienceEntraToken(ctx, id)
 	if err != nil {
-		return azcore.AccessToken{}, fmt.Errorf("failed to get ARM access token: %w", err)
+		return azcore.AccessToken{}, fmt.Errorf("failed to get ACR audience Entra token: %w", err)
 	}
 
-	return ExchangeACRAccessToken(ctx, armToken, acrFQDN, scope)
+	return ExchangeACRAccessToken(ctx, acrAudienceEntraToken, acrFQDN, scope)
 }

--- a/pkg/authorizer/token_exchanger.go
+++ b/pkg/authorizer/token_exchanger.go
@@ -16,8 +16,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry"
 )
 
-// ExchangeACRAccessToken exchanges an ARM access token to an ACR access token
-func ExchangeACRAccessToken(ctx context.Context, armToken azcore.AccessToken, acrFQDN, scope string) (azcore.AccessToken, error) {
+// ExchangeACRAccessToken exchanges an ACR audience Entra token to an actual ACR access token
+func ExchangeACRAccessToken(ctx context.Context, acrAudienceEntraToken azcore.AccessToken, acrFQDN, scope string) (azcore.AccessToken, error) {
 	endpoint, err := url.Parse(fmt.Sprintf("https://%s", acrFQDN))
 	if err != nil {
 		return azcore.AccessToken{}, fmt.Errorf("failed to parse ACR endpoint: %w", err)
@@ -28,7 +28,7 @@ func ExchangeACRAccessToken(ctx context.Context, armToken azcore.AccessToken, ac
 		return azcore.AccessToken{}, fmt.Errorf("failed to create ACR authentication client: %w", err)
 	}
 	refreshResponse, err := client.ExchangeAADAccessTokenForACRRefreshToken(ctx, azcontainerregistry.PostContentSchemaGrantTypeAccessToken, endpoint.Hostname(), &azcontainerregistry.AuthenticationClientExchangeAADAccessTokenForACRRefreshTokenOptions{
-		AccessToken: ptr.To(armToken.Token),
+		AccessToken: ptr.To(acrAudienceEntraToken.Token),
 	})
 	if err != nil {
 		return azcore.AccessToken{}, fmt.Errorf("failed to exchange AAD access token for ACR refresh token: %w", err)
@@ -80,6 +80,6 @@ func ExchangeACRAccessToken(ctx context.Context, armToken azcore.AccessToken, ac
 	}, nil
 }
 
-func ExchangeACRAccessTokenForSpec(ctx context.Context, armToken azcore.AccessToken, spec msiacrpullv1beta2.AcrConfiguration) (azcore.AccessToken, error) {
-	return ExchangeACRAccessToken(ctx, armToken, spec.Server, spec.Scope)
+func ExchangeACRAccessTokenForSpec(ctx context.Context, acrAudienceEntraToken azcore.AccessToken, spec msiacrpullv1beta2.AcrConfiguration) (azcore.AccessToken, error) {
+	return ExchangeACRAccessToken(ctx, acrAudienceEntraToken, spec.Server, spec.Scope)
 }


### PR DESCRIPTION
This PR updates the authentication logic to request Microsoft Entra tokens scoped for the Azure Container Registry (ACR) audience (https://containerregistry.azure.net) instead of the default Azure Resource Manager (ARM) audience (https://management.azure.com).

This change ensures the audience of Entra tokens is scoped only for ACR, aligning with the security best practices outlined in [ACR's authentication guidance](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-disable-authentication-as-arm).

The update was driven by increased adoption of registries that explicitly disable the authentication-as-arm property, requiring Entra tokens scoped exclusively to the ACR audience.

This change is backwards compatible: registries that still accept ARM-scoped tokens (authentication-as-arm enabled) will continue to authenticate successfully without interruption.