### PR TITLE
adding label selector to controller for watching acrpullbindings

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,7 +52,7 @@ func main() {
 	var probeAddr string
 	var serviceAccountTokenAudience string
 	var ttlRotationFraction float64
-	var labelSelectorValue string
+	var labelSelectorString string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -60,7 +60,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&serviceAccountTokenAudience, "service-account-token-audience", "api://AzureCRTokenExchange", "The audience to ask the Kubernetes API server to mint Service Account tokens for, must match Federated Identity Credential configuration in Azure.")
 	flag.Float64Var(&ttlRotationFraction, "ttl-rotation-fraction", 0.5, "The fraction of the pull token's TTL at which the v1beta2 reconciler will refresh the token.")
-	flag.StringVar(&labelSelectorValue, "label-selector", "", "Label value to watch for AcrPullBindings")
+	flag.StringVar(&labelSelectorString, "label-selector", "", "Label value to watch for AcrPullBindings")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -134,8 +134,9 @@ func main() {
 		DefaultManagedIdentityResourceID: defaultManagedIdentityResourceID,
 		DefaultManagedIdentityClientID:   defaultManagedIdentityClientID,
 		DefaultACRServer:                 defaultACRServer,
+		PullBindingLabelSelectorString:   labelSelectorString,
 	})
-	if err := apbReconciler.SetupWithManager(ctx, mgr, labelSelectorValue); err != nil {
+	if err := apbReconciler.SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AcrPullBinding")
 		os.Exit(1)
 	}
@@ -151,11 +152,12 @@ func main() {
 			Logger: ctrl.Log.WithName("controller").WithName("AcrPullBindingV1beta2"),
 			Scheme: mgr.GetScheme(),
 		},
-		TTLRotationFraction:         ttlRotationFraction,
-		ServiceAccountTokenAudience: serviceAccountTokenAudience,
-		ServiceAccountClient:        kubeClient.CoreV1(),
+		TTLRotationFraction:            ttlRotationFraction,
+		ServiceAccountTokenAudience:    serviceAccountTokenAudience,
+		ServiceAccountClient:           kubeClient.CoreV1(),
+		PullBindingLabelSelectorString: labelSelectorString,
 	})
-	if err := v1beta2Reconciler.SetupWithManager(ctx, mgr, labelSelectorValue); err != nil {
+	if err := v1beta2Reconciler.SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AcrPullBindingV1beta2")
 		os.Exit(1)
 	}

--- a/internal/controller/acrpullbinding_controller.go
+++ b/internal/controller/acrpullbinding_controller.go
@@ -229,10 +229,14 @@ func (r *AcrPullBindingReconciler) SetupWithManager(ctx context.Context, mgr ctr
 
 	var eventFilter predicate.Predicate
 	if labelSelectorValue != "" {
-		eventFilter = predicate.NewPredicateFuncs(func(obj client.Object) bool {
-			_, ok := obj.GetLabels()["acr.microsoft.com/xyz"]
-			return ok
-		})
+		selector, err := metav1.ParseToLabelSelector(labelSelectorValue)
+		if err != nil {
+			return fmt.Errorf("failed to parse label selector %q: %w", labelSelectorValue, err)
+		}
+		eventFilter, err = predicate.LabelSelectorPredicate(*selector)
+		if err != nil {
+			return fmt.Errorf("failed to create label selector predicate for %q: %w", labelSelectorValue, err)
+		}
 	} else {
 		eventFilter = predicate.NewPredicateFuncs(func(obj client.Object) bool { return true })
 	}

--- a/internal/controller/acrpullbinding_controller.go
+++ b/internal/controller/acrpullbinding_controller.go
@@ -19,8 +19,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -251,8 +253,19 @@ func (r *AcrPullBindingReconciler) SetupWithManager(ctx context.Context, mgr ctr
 		return err
 	}
 
+	labelSelector, err := r.LabelSelector()
+	if err != nil {
+		return fmt.Errorf("failed to get label selector: %w", err)
+	}
+	eventFilter := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		if labelSelector == nil {
+			return true
+		}
+		return labelSelector.Matches(labels.Set(obj.GetLabels()))
+	})
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&msiacrpullv1beta1.AcrPullBinding{}).
+		For(&msiacrpullv1beta1.AcrPullBinding{}, builder.WithPredicates(eventFilter)).
 		Named("acr-pull-binding").
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(enqueuePullBindingsForPullSecret(mgr))).
 		Watches(&corev1.ServiceAccount{}, handler.EnqueueRequestsFromMapFunc(enqueuePullBindingsForServiceAccount(mgr))).

--- a/internal/controller/acrpullbinding_v1beta2_controller.go
+++ b/internal/controller/acrpullbinding_v1beta2_controller.go
@@ -18,8 +18,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -193,8 +196,19 @@ func (r *PullBindingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 	// n.b. we do not need to add the imagePullSecretsField indexer on service accounts since v1beta1 controller does it
 	// n.b. we do not need to add the pullBindingField indexer on service accounts since v1beta1 controller does it
 
+	labelSelector, err := r.LabelSelector()
+	if err != nil {
+		return fmt.Errorf("failed to get label selector: %w", err)
+	}
+	eventFilter := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		if labelSelector == nil {
+			return true
+		}
+		return labelSelector.Matches(labels.Set(obj.GetLabels()))
+	})
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&msiacrpullv1beta2.AcrPullBinding{}).
+		For(&msiacrpullv1beta2.AcrPullBinding{}, builder.WithPredicates(eventFilter)).
 		Named("acr-pull-binding-v1beta2").
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(enqueuePullBindingsForPullSecret(mgr))).
 		Watches(&corev1.ServiceAccount{}, handler.EnqueueRequestsFromMapFunc(enqueueV1beta2PullBindingsForServiceAccount(mgr))).

--- a/internal/controller/acrpullbinding_v1beta2_controller.go
+++ b/internal/controller/acrpullbinding_v1beta2_controller.go
@@ -193,10 +193,14 @@ func (r *PullBindingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 
 	var eventFilter predicate.Predicate
 	if labelSelectorValue != "" {
-		eventFilter = predicate.NewPredicateFuncs(func(obj client.Object) bool {
-			_, ok := obj.GetLabels()["acr.microsoft.com/xyz"]
-			return ok
-		})
+		selector, err := metav1.ParseToLabelSelector(labelSelectorValue)
+		if err != nil {
+			return fmt.Errorf("failed to parse label selector %q: %w", labelSelectorValue, err)
+		}
+		eventFilter, err = predicate.LabelSelectorPredicate(*selector)
+		if err != nil {
+			return fmt.Errorf("failed to create label selector predicate for %q: %w", labelSelectorValue, err)
+		}
 	} else {
 		eventFilter = predicate.NewPredicateFuncs(func(obj client.Object) bool { return true })
 	}

--- a/internal/controller/acrpullbinding_v1beta2_controller.go
+++ b/internal/controller/acrpullbinding_v1beta2_controller.go
@@ -14,14 +14,12 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -41,9 +39,10 @@ type armAcrTokenExchanger func(ctx context.Context, armToken azcore.AccessToken,
 type V1beta2ReconcilerOpts struct {
 	CoreOpts
 
-	TTLRotationFraction         float64
-	ServiceAccountClient        corev1client.ServiceAccountsGetter
-	ServiceAccountTokenAudience string
+	TTLRotationFraction            float64
+	ServiceAccountClient           corev1client.ServiceAccountsGetter
+	ServiceAccountTokenAudience    string
+	PullBindingLabelSelectorString string
 
 	// exposed here to allow unit tests to over-write them
 	mintToken                   ServiceAccountTokenMinter
@@ -174,6 +173,9 @@ func NewV1beta2Reconciler(opts *V1beta2ReconcilerOpts) *PullBindingReconciler {
 				updated.Status.Error = ""
 				return updated
 			},
+			LabelSelector: func() (labels.Selector, error) {
+				return acrPullBindingLabelSelector(opts.PullBindingLabelSelectorString)
+			},
 			now: opts.now,
 		},
 	}
@@ -184,29 +186,15 @@ type PullBindingReconciler struct {
 	*genericReconciler[*msiacrpullv1beta2.AcrPullBinding]
 }
 
-func (r *PullBindingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, labelSelectorValue string) error {
+func (r *PullBindingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &msiacrpullv1beta2.AcrPullBinding{}, serviceAccountField, indexV1beta2PullBindingByServiceAccount); err != nil {
 		return err
 	}
 	// n.b. we do not need to add the imagePullSecretsField indexer on service accounts since v1beta1 controller does it
 	// n.b. we do not need to add the pullBindingField indexer on service accounts since v1beta1 controller does it
 
-	var eventFilter predicate.Predicate
-	if labelSelectorValue != "" {
-		selector, err := metav1.ParseToLabelSelector(labelSelectorValue)
-		if err != nil {
-			return fmt.Errorf("failed to parse label selector %q: %w", labelSelectorValue, err)
-		}
-		eventFilter, err = predicate.LabelSelectorPredicate(*selector)
-		if err != nil {
-			return fmt.Errorf("failed to create label selector predicate for %q: %w", labelSelectorValue, err)
-		}
-	} else {
-		eventFilter = predicate.NewPredicateFuncs(func(obj client.Object) bool { return true })
-	}
-
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&msiacrpullv1beta2.AcrPullBinding{}, builder.WithPredicates(eventFilter)).
+		For(&msiacrpullv1beta2.AcrPullBinding{}).
 		Named("acr-pull-binding-v1beta2").
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(enqueuePullBindingsForPullSecret(mgr))).
 		Watches(&corev1.ServiceAccount{}, handler.EnqueueRequestsFromMapFunc(enqueueV1beta2PullBindingsForServiceAccount(mgr))).

--- a/internal/controller/generic_controller.go
+++ b/internal/controller/generic_controller.go
@@ -63,16 +63,14 @@ func (r *genericReconciler[O]) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
-	if r.LabelSelector != nil {
-		selector, err := r.LabelSelector()
-		if err != nil {
-			logger.Error(err, "failed to get label selector")
-			return ctrl.Result{}, fmt.Errorf("failed to get label selector: %w", err)
-		}
-		if !selector.Matches(labels.Set(acrBinding.GetLabels())) {
-			logger.Info("skipping reconcile: label selector %q does not match %q labels", selector.String(), acrBinding.GetName())
-			return ctrl.Result{}, nil
-		}
+	selector, err := r.LabelSelector()
+	if err != nil {
+		logger.Error(err, "failed to get label selector")
+		return ctrl.Result{}, fmt.Errorf("failed to get label selector: %w", err)
+	}
+	if selector != nil && !selector.Matches(labels.Set(acrBinding.GetLabels())) {
+		logger.Info("skipping reconcile: label selector %q does not match %q labels", selector.String(), acrBinding.GetName())
+		return ctrl.Result{}, nil
 	}
 
 	serviceAccount := &corev1.ServiceAccount{}


### PR DESCRIPTION
Adding support for a label selector to the acrpull controller. When a label selector is provided via CLI arguments (e.g., through the deployment), the controller will only watch and reconcile AcrPullBinding resources that match the given selector.