### PR TITLE
Remove explicit `GOEXPERIMENT=systemcrypto`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY ./ ./
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN GOEXPERIMENT=systemcrypto,ms_nocgo_opensslcrypto GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager -tags=requirefips cmd/main.go
+RUN GOEXPERIMENT=ms_nocgo_opensslcrypto GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager -tags=requirefips cmd/main.go
 
 FROM mcr.microsoft.com/azurelinux/base/core:3.0
 WORKDIR /


### PR DESCRIPTION
Microsoft build of Go maintainer here. SystemCrypto is enabled by default since Go 1.25, no need to set it manually (see [docs](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/MigrationGuide.md#enable-systemcrypto)). That experiment will most likely disappear in Go 1.27, so removing it now will safe you from a build error once upgrading to Go 1.27.