### PR TITLE
Add CodeQL analysis workflow for Go (Continuous SDL / S360)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+# CodeQL analysis for Continuous SDL / S360 compliance.
+# Produces a CodeQL snapshot for the Go code in this repository on a schedule,
+# on pushes to the default branch, and on PRs.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly on Monday 09:00 UTC (keeps the snapshot < 30 days old for SDL CA).
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (go)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["go"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4dd16135b69a43b6c8efb853346f8437d92d3c93 # v3.26.6
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: autobuild
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@4dd16135b69a43b6c8efb853346f8437d92d3c93 # v3.26.6
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Purpose
Add a scheduled **CodeQL** analysis workflow for the Go code in this repository to satisfy the Continuous SDL (S360) CodeQL requirement, which needs a fresh CodeQL snapshot at least every 30 days.

## What this does
- Runs CodeQL for `go` on pushes to `main`, on PRs, weekly (Mon 09:00 UTC), and via manual dispatch.
- Uses `build-mode: autobuild` (this repo is a single Go module rooted at the repository root).
- Action versions pinned to a commit SHA.

Modeled after Azure/kube-state-logs#31. No production code is changed.