### PR TITLE
Minor controller improvements

### DIFF
--- a/internal/controller/acrpullbinding_controller.go
+++ b/internal/controller/acrpullbinding_controller.go
@@ -379,3 +379,23 @@ func newPullSecret(acrBinding client.Object,
 
 	return pullSecret
 }
+
+func pullSecretForUpdate(existing, desired *corev1.Secret) *corev1.Secret {
+	updated := existing.DeepCopy()
+	updated.Type = desired.Type
+	updated.Data = desired.Data
+
+	if updated.Labels == nil {
+		updated.Labels = map[string]string{}
+	}
+	updated.Labels[ACRPullBindingLabel] = desired.Labels[ACRPullBindingLabel]
+
+	if updated.Annotations == nil {
+		updated.Annotations = map[string]string{}
+	}
+	for _, annotation := range []string{tokenExpiryAnnotation, tokenRefreshAnnotation, tokenInputsAnnotation} {
+		updated.Annotations[annotation] = desired.Annotations[annotation]
+	}
+
+	return updated
+}

--- a/internal/controller/acrpullbinding_controller.go
+++ b/internal/controller/acrpullbinding_controller.go
@@ -112,6 +112,9 @@ func NewV1beta1Reconciler(opts *V1beta1ReconcilerOpts) *AcrPullBindingReconciler
 
 				return dockerConfig, acrAccessToken.ExpiresOn, nil
 			},
+			GetStatusError: func(binding *msiacrpullv1beta1.AcrPullBinding) string {
+				return binding.Status.Error
+			},
 			UpdateStatusError: func(binding *msiacrpullv1beta1.AcrPullBinding, s string) *msiacrpullv1beta1.AcrPullBinding {
 				updated := binding.DeepCopy()
 				updated.Status.Error = s

--- a/internal/controller/acrpullbinding_controller_test.go
+++ b/internal/controller/acrpullbinding_controller_test.go
@@ -299,6 +299,7 @@ func Test_ACRPullBindingController_reconcile(t *testing.T) {
 						Error: `failed to retrieve ACR access token: oops`,
 					},
 				},
+				retryError: `failed to retrieve ACR access token: oops`,
 			},
 		},
 		{

--- a/internal/controller/acrpullbinding_v1beta2_controller.go
+++ b/internal/controller/acrpullbinding_v1beta2_controller.go
@@ -119,7 +119,7 @@ func NewV1beta2Reconciler(opts *V1beta2ReconcilerOpts) *PullBindingReconciler {
 						} {
 							value, set := serviceAccount.Annotations[annotation.value]
 							if !set {
-								return "", time.Time{}, fmt.Errorf("service account %s missing %s annotation", serviceAccount.Name, annotation.value)
+								return "", time.Time{}, permanentCredentialError{fmt.Errorf("service account %s missing %s annotation", serviceAccount.Name, annotation.value)}
 							}
 							*annotation.into = value
 						}

--- a/internal/controller/acrpullbinding_v1beta2_controller.go
+++ b/internal/controller/acrpullbinding_v1beta2_controller.go
@@ -118,7 +118,7 @@ func NewV1beta2Reconciler(opts *V1beta2ReconcilerOpts) *PullBindingReconciler {
 							{value: azworkloadidentity.TenantIDAnnotation, into: &tenantId},
 						} {
 							value, set := serviceAccount.Annotations[annotation.value]
-							if !set {
+							if !set || value == "" {
 								return "", time.Time{}, permanentCredentialError{fmt.Errorf("service account %s missing %s annotation", serviceAccount.Name, annotation.value)}
 							}
 							*annotation.into = value
@@ -147,6 +147,9 @@ func NewV1beta2Reconciler(opts *V1beta2ReconcilerOpts) *PullBindingReconciler {
 					return "", time.Time{}, fmt.Errorf("failed to write ACR dockercfg: %v", err)
 				}
 				return dockerConfig, acrToken.ExpiresOn, nil
+			},
+			GetStatusError: func(binding *msiacrpullv1beta2.AcrPullBinding) string {
+				return binding.Status.Error
 			},
 			UpdateStatusError: func(binding *msiacrpullv1beta2.AcrPullBinding, s string) *msiacrpullv1beta2.AcrPullBinding {
 				updated := binding.DeepCopy()

--- a/internal/controller/acrpullbinding_v1beta2_controller_test.go
+++ b/internal/controller/acrpullbinding_v1beta2_controller_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -1597,6 +1598,59 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 			output := controller.reconcile(context.Background(), logger, testCase.acrBinding, testCase.serviceAccount, testCase.pullSecrets, testCase.referencingServiceAccounts)
 			if diff := cmp.Diff(testCase.output, output, cmp.AllowUnexported(action[*msiacrpullv1beta2.AcrPullBinding]{})); diff != "" {
 				t.Errorf("-want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestV1beta2CreatePullCredentialRejectsEmptyWorkloadIdentityAnnotations(t *testing.T) {
+	binding := &msiacrpullv1beta2.AcrPullBinding{
+		Spec: msiacrpullv1beta2.AcrPullBindingSpec{
+			Auth: msiacrpullv1beta2.AuthenticationMethod{
+				WorkloadIdentity: &msiacrpullv1beta2.WorkloadIdentityAuth{},
+			},
+		},
+	}
+
+	for _, testCase := range []struct {
+		name        string
+		annotations map[string]string
+		wantError   string
+	}{
+		{
+			name: "empty client ID",
+			annotations: map[string]string{
+				"azure.workload.identity/client-id": "",
+				"azure.workload.identity/tenant-id": "tenant-id",
+			},
+			wantError: "missing azure.workload.identity/client-id annotation",
+		},
+		{
+			name: "empty tenant ID",
+			annotations: map[string]string{
+				"azure.workload.identity/client-id": "client-id",
+				"azure.workload.identity/tenant-id": "",
+			},
+			wantError: "missing azure.workload.identity/tenant-id annotation",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			controller := NewV1beta2Reconciler(&V1beta2ReconcilerOpts{
+				mintToken: func(context.Context, string, string) (*authenticationv1.TokenRequest, error) {
+					t.Fatal("mintToken called for invalid workload identity annotations")
+					return nil, nil
+				},
+			})
+			serviceAccount := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "delegate", Annotations: testCase.annotations},
+			}
+
+			_, _, err := controller.CreatePullCredential(context.Background(), binding, serviceAccount)
+			if err == nil || !strings.Contains(err.Error(), testCase.wantError) {
+				t.Fatalf("expected %q, got %v", testCase.wantError, err)
+			}
+			if !isPermanentCredentialError(err) {
+				t.Fatalf("expected permanent credential error, got %T: %v", err, err)
 			}
 		})
 	}

--- a/internal/controller/acrpullbinding_v1beta2_controller_test.go
+++ b/internal/controller/acrpullbinding_v1beta2_controller_test.go
@@ -396,6 +396,7 @@ func Test_ACRPullBindingController_v1beta2_reconcile(t *testing.T) {
 						Error: `failed to retrieve ARM token: oops`,
 					},
 				},
+				retryError: `failed to retrieve ARM token: oops`,
 			},
 		},
 		{

--- a/internal/controller/generic_controller.go
+++ b/internal/controller/generic_controller.go
@@ -39,6 +39,7 @@ type genericReconciler[O pullBinding] struct {
 
 	CreatePullCredential func(context.Context, O, *corev1.ServiceAccount) (string, time.Time, error)
 
+	GetStatusError    func(O) string
 	UpdateStatusError func(O, string) O
 
 	NeedsRefresh func(logr.Logger, *corev1.Secret, func() time.Time) bool
@@ -141,7 +142,7 @@ func (r *genericReconciler[O]) reconcile(ctx context.Context, logger logr.Logger
 	if r.ValidateBinding != nil {
 		if err := r.ValidateBinding(acrBinding); err != nil {
 			logger.Info(err.Error())
-			return &action[O]{updatePullBindingStatus: r.UpdateStatusError(acrBinding, err.Error())}
+			return r.statusErrorAction(acrBinding, err.Error(), false)
 		}
 	}
 
@@ -170,7 +171,7 @@ func (r *genericReconciler[O]) reconcile(ctx context.Context, logger logr.Logger
 	if serviceAccount == nil {
 		err := fmt.Sprintf("service account %q not found", r.GetServiceAccountName(acrBinding))
 		logger.Info(err)
-		return &action[O]{updatePullBindingStatus: r.UpdateStatusError(acrBinding, err)}
+		return r.statusErrorAction(acrBinding, err, false)
 	}
 
 	expectedPullSecretName := r.GetPullSecretName(acrBinding)
@@ -190,13 +191,7 @@ func (r *genericReconciler[O]) reconcile(ctx context.Context, logger logr.Logger
 		dockerConfig, expiresOn, err := r.CreatePullCredential(ctx, acrBinding, serviceAccount)
 		if err != nil {
 			logger.Error(err, "failed to generate pull credential")
-			action := &action[O]{
-				updatePullBindingStatus: r.UpdateStatusError(acrBinding, err.Error()),
-			}
-			if !isPermanentCredentialError(err) {
-				action.retryError = err.Error()
-			}
-			return action
+			return r.statusErrorAction(acrBinding, err.Error(), !isPermanentCredentialError(err))
 		}
 
 		newSecret := newPullSecret(acrBinding, r.GetPullSecretName(acrBinding), dockerConfig, r.Scheme, expiresOn, r.now, inputHash)
@@ -251,6 +246,21 @@ func (r *genericReconciler[O]) reconcile(ctx context.Context, logger logr.Logger
 	}
 
 	return r.setSuccessStatus(logger, acrBinding, pullSecret)
+}
+
+func (r *genericReconciler[O]) statusErrorAction(acrBinding O, message string, retry bool) *action[O] {
+	if r.GetStatusError(acrBinding) == message {
+		if retry {
+			return &action[O]{retryError: message}
+		}
+		return nil
+	}
+
+	action := &action[O]{updatePullBindingStatus: r.UpdateStatusError(acrBinding, message)}
+	if retry {
+		action.retryError = message
+	}
+	return action
 }
 
 // sortPullSecrets ensures the semantically-correct ordering of pull secrets for the service account. The order of pull
@@ -414,6 +424,9 @@ func (a *action[O]) execute(ctx context.Context, logger logr.Logger, client crcl
 	} else if a.updateServiceAccount != nil {
 		return ctrl.Result{}, client.Update(ctx, a.updateServiceAccount)
 	}
+	if a.retryError != "" {
+		return ctrl.Result{}, fmt.Errorf("retrying after credential generation failure: %s", a.retryError)
+	}
 	logger.Info("no action taken")
 	return ctrl.Result{}, nil
 }
@@ -462,9 +475,6 @@ type action[O pullBinding] struct {
 }
 
 func (a *action[O]) validate() {
-	if a.retryError != "" && a.updatePullBindingStatus == nil {
-		panic("programmer error: retry error specified without a status update")
-	}
 	var present int
 	if a.updatePullBinding != nil {
 		present++

--- a/internal/controller/generic_controller.go
+++ b/internal/controller/generic_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -188,8 +189,14 @@ func (r *genericReconciler[O]) reconcile(ctx context.Context, logger logr.Logger
 
 		dockerConfig, expiresOn, err := r.CreatePullCredential(ctx, acrBinding, serviceAccount)
 		if err != nil {
-			logger.Info(err.Error())
-			return &action[O]{updatePullBindingStatus: r.UpdateStatusError(acrBinding, err.Error())}
+			logger.Error(err, "failed to generate pull credential")
+			action := &action[O]{
+				updatePullBindingStatus: r.UpdateStatusError(acrBinding, err.Error()),
+			}
+			if !isPermanentCredentialError(err) {
+				action.retryError = err.Error()
+			}
+			return action
 		}
 
 		newSecret := newPullSecret(acrBinding, r.GetPullSecretName(acrBinding), dockerConfig, r.Scheme, expiresOn, r.now, inputHash)
@@ -199,7 +206,7 @@ func (r *genericReconciler[O]) reconcile(ctx context.Context, logger logr.Logger
 			return &action[O]{createSecret: newSecret}
 		} else {
 			logger.Info("updating pull credential secret")
-			return &action[O]{updateSecret: newSecret}
+			return &action[O]{updateSecret: pullSecretForUpdate(pullSecret, newSecret)}
 		}
 	}
 
@@ -391,7 +398,13 @@ func (a *action[O]) execute(ctx context.Context, logger logr.Logger, client crcl
 	} else if a.updatePullBindingStatus != nil {
 		after := clampRequeue(refresh(a.updatePullBindingStatus))
 		logger.WithValues("requeueAfter", after).Info("re-queueing for later processing")
-		return ctrl.Result{RequeueAfter: after}, client.Status().Update(ctx, a.updatePullBindingStatus)
+		if err := client.Status().Update(ctx, a.updatePullBindingStatus); err != nil {
+			return ctrl.Result{}, err
+		}
+		if a.retryError != "" {
+			return ctrl.Result{}, fmt.Errorf("retrying after credential generation failure: %s", a.retryError)
+		}
+		return ctrl.Result{RequeueAfter: after}, nil
 	} else if a.createSecret != nil {
 		return ctrl.Result{}, client.Create(ctx, a.createSecret)
 	} else if a.updateSecret != nil {
@@ -425,11 +438,21 @@ type pullBinding interface {
 	crclient.Object
 }
 
+type permanentCredentialError struct {
+	error
+}
+
+func isPermanentCredentialError(err error) bool {
+	var permanent permanentCredentialError
+	return errors.As(err, &permanent)
+}
+
 // action captures the outcome of a reconciliation pass using static data, to aid in testing the reconciliation loop
 type action[O pullBinding] struct {
 	updatePullBinding       O
 	noop                    O
 	updatePullBindingStatus O
+	retryError              string
 
 	createSecret *corev1.Secret
 	updateSecret *corev1.Secret
@@ -439,6 +462,9 @@ type action[O pullBinding] struct {
 }
 
 func (a *action[O]) validate() {
+	if a.retryError != "" && a.updatePullBindingStatus == nil {
+		panic("programmer error: retry error specified without a status update")
+	}
 	var present int
 	if a.updatePullBinding != nil {
 		present++

--- a/internal/controller/generic_controller_test.go
+++ b/internal/controller/generic_controller_test.go
@@ -151,6 +151,47 @@ func TestActionExecutePersistsStatusAndReturnsTransientError(t *testing.T) {
 	}
 }
 
+func TestActionExecuteReturnsTransientErrorWithoutStatusUpdate(t *testing.T) {
+	client := &recordingClient{statusWriter: &recordingStatusWriter{}}
+	result, err := (&action[*msiacrpullv1beta1.AcrPullBinding]{
+		retryError: "temporary Azure outage",
+	}).execute(
+		context.Background(),
+		logr.Discard(),
+		client,
+		func(*msiacrpullv1beta1.AcrPullBinding) time.Duration { return 0 },
+	)
+	if err == nil || !strings.Contains(err.Error(), "temporary Azure outage") {
+		t.Fatalf("expected transient reconcile error, got %v", err)
+	}
+	if !result.IsZero() {
+		t.Fatalf("expected controller-runtime to determine backoff, got %#v", result)
+	}
+	if client.statusWriter.updated != nil {
+		t.Fatalf("expected no status update, got %T", client.statusWriter.updated)
+	}
+}
+
+func TestStatusErrorActionSkipsUnchangedStatus(t *testing.T) {
+	binding := &msiacrpullv1beta1.AcrPullBinding{
+		Status: msiacrpullv1beta1.AcrPullBindingStatus{Error: "temporary Azure outage"},
+	}
+	reconciler := &genericReconciler[*msiacrpullv1beta1.AcrPullBinding]{
+		GetStatusError: func(binding *msiacrpullv1beta1.AcrPullBinding) string {
+			return binding.Status.Error
+		},
+		UpdateStatusError: func(binding *msiacrpullv1beta1.AcrPullBinding, message string) *msiacrpullv1beta1.AcrPullBinding {
+			t.Fatal("unchanged status should not be updated")
+			return nil
+		},
+	}
+
+	action := reconciler.statusErrorAction(binding, binding.Status.Error, true)
+	if action.updatePullBindingStatus != nil || action.retryError != binding.Status.Error {
+		t.Fatalf("expected retry without status update, got %#v", action)
+	}
+}
+
 type recordingClient struct {
 	crclient.Client
 	updated      crclient.Object

--- a/internal/controller/generic_controller_test.go
+++ b/internal/controller/generic_controller_test.go
@@ -1,10 +1,18 @@
 package controller
 
 import (
+	"context"
+	"strings"
 	"testing"
+	"time"
 
+	msiacrpullv1beta1 "github.com/Azure/msi-acrpull/api/v1beta1"
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestSortPullSecrets(t *testing.T) {
@@ -40,4 +48,130 @@ func TestSortPullSecrets(t *testing.T) {
 			t.Errorf("%T differ (-got, +want): %s", testCase.in, diff)
 		}
 	}
+}
+
+func TestPullSecretForUpdatePreservesMetadataAndExecutes(t *testing.T) {
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "ns",
+			Name:            "pull-secret",
+			ResourceVersion: "7",
+			UID:             types.UID("existing-uid"),
+			Labels: map[string]string{
+				"custom-label":      "preserved",
+				ACRPullBindingLabel: "old-binding",
+			},
+			Annotations: map[string]string{
+				"custom-annotation":   "preserved",
+				tokenExpiryAnnotation: "old-expiry",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"old": []byte("data")},
+	}
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "pull-secret",
+			Labels:    map[string]string{ACRPullBindingLabel: "binding"},
+			Annotations: map[string]string{
+				tokenExpiryAnnotation:  "new-expiry",
+				tokenRefreshAnnotation: "new-refresh",
+				tokenInputsAnnotation:  "new-inputs",
+			},
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{dockerConfigKey: []byte("new-data")},
+	}
+
+	updated := pullSecretForUpdate(existing, desired)
+	if updated.ResourceVersion != existing.ResourceVersion || updated.UID != existing.UID {
+		t.Fatalf("server metadata was not preserved: %#v", updated.ObjectMeta)
+	}
+	if updated.Labels["custom-label"] != "preserved" || updated.Annotations["custom-annotation"] != "preserved" {
+		t.Fatalf("custom metadata was not preserved: labels=%v annotations=%v", updated.Labels, updated.Annotations)
+	}
+
+	client := &recordingClient{}
+	result, err := (&action[*msiacrpullv1beta1.AcrPullBinding]{updateSecret: updated}).execute(
+		context.Background(),
+		logr.Discard(),
+		client,
+		func(*msiacrpullv1beta1.AcrPullBinding) time.Duration { return 0 },
+	)
+	if err != nil {
+		t.Fatalf("failed to update existing Secret: %v", err)
+	}
+	if !result.IsZero() {
+		t.Fatalf("expected empty result, got %#v", result)
+	}
+
+	stored, ok := client.updated.(*corev1.Secret)
+	if !ok {
+		t.Fatalf("expected updated Secret, got %T", client.updated)
+	}
+	if diff := cmp.Diff(desired.Data, stored.Data); diff != "" {
+		t.Errorf("Secret data differs (-want, +got): %s", diff)
+	}
+	if stored.Labels["custom-label"] != "preserved" || stored.Annotations["custom-annotation"] != "preserved" {
+		t.Errorf("stored custom metadata was not preserved: labels=%v annotations=%v", stored.Labels, stored.Annotations)
+	}
+}
+
+func TestActionExecutePersistsStatusAndReturnsTransientError(t *testing.T) {
+	binding := &msiacrpullv1beta1.AcrPullBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "binding"},
+	}
+	client := &recordingClient{statusWriter: &recordingStatusWriter{}}
+
+	updated := binding.DeepCopy()
+	updated.Status.Error = "temporary Azure outage"
+	result, err := (&action[*msiacrpullv1beta1.AcrPullBinding]{
+		updatePullBindingStatus: updated,
+		retryError:              updated.Status.Error,
+	}).execute(
+		context.Background(),
+		logr.Discard(),
+		client,
+		func(*msiacrpullv1beta1.AcrPullBinding) time.Duration { return 0 },
+	)
+	if err == nil || !strings.Contains(err.Error(), updated.Status.Error) {
+		t.Fatalf("expected transient reconcile error, got %v", err)
+	}
+	if !result.IsZero() {
+		t.Fatalf("expected controller-runtime to determine backoff, got %#v", result)
+	}
+
+	stored, ok := client.statusWriter.updated.(*msiacrpullv1beta1.AcrPullBinding)
+	if !ok {
+		t.Fatalf("expected updated binding status, got %T", client.statusWriter.updated)
+	}
+	if stored.Status.Error != updated.Status.Error {
+		t.Fatalf("expected persisted status error %q, got %q", updated.Status.Error, stored.Status.Error)
+	}
+}
+
+type recordingClient struct {
+	crclient.Client
+	updated      crclient.Object
+	statusWriter *recordingStatusWriter
+}
+
+func (c *recordingClient) Update(_ context.Context, obj crclient.Object, _ ...crclient.UpdateOption) error {
+	c.updated = obj.DeepCopyObject().(crclient.Object)
+	return nil
+}
+
+func (c *recordingClient) Status() crclient.SubResourceWriter {
+	return c.statusWriter
+}
+
+type recordingStatusWriter struct {
+	crclient.SubResourceWriter
+	updated crclient.Object
+}
+
+func (w *recordingStatusWriter) Update(_ context.Context, obj crclient.Object, _ ...crclient.SubResourceUpdateOption) error {
+	w.updated = obj.DeepCopyObject().(crclient.Object)
+	return nil
 }


### PR DESCRIPTION
Fix in-place pull Secret rotation & Guarantee retry after transient cred failures

Improve pull credential maintenance reliability

Preserve Kubernetes Secret metadata during credential rotation and return transient credential failures for controller-runtime retry while keeping configuration errors terminal. Add regression coverage for in-place Secret updates and status persistence before retry.